### PR TITLE
Added node version to basic image

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
-          build-args: VERSION=${{ env.NODE_VERSION }}
+          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
           load: true
           tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }},apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
       -
@@ -71,7 +71,7 @@ jobs:
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
-          build-args: VERSION=${{ env.NODE_VERSION }}
+          build-args: NODE_VERSION=${{ env.NODE_VERSION }}
           load: true
           tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
  
@@ -80,7 +80,7 @@ jobs:
         run: docker run apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
       -
         name: Test image with node version tag
-        if: ${{ matrix.image-name == 'node' }}
+        if: ${{ env.RELEASE_TAG == 'latest' }}
         run: docker run apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
       -
         name: Login to DockerHub

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
+          build-args: VERSION=${{ env.NODE_VERSION }}
           load: true
           tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }},apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
       -
@@ -70,6 +71,7 @@ jobs:
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
+          build-args: VERSION=${{ env.NODE_VERSION }}
           load: true
           tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
  

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -1,0 +1,95 @@
+name: Release node image
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag for the images (e.g.: beta)'
+        required: true
+      apify_version:
+        description: 'Apify SDK version (e.g.: ^1.0.0)'
+        required: true
+      node_version:
+        description: 'NodeJs version for image actor-node'
+        required: false
+        default: '14'
+
+  repository_dispatch:
+    types: [ build-images ]
+
+env:
+  RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag }}
+  APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
+  NODE_VERSION: ${{ github.event.client_payload.node_version || github.event.inputs.node_version }}
+
+jobs:
+  # Build master images that are not dependent on existing builds.
+  build-main:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image-name: [node]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Set Dependency Versions
+        run: |
+          cd ${{ matrix.image-name }}
+          node ../.github/scripts/set-dependency-versions.js
+      -
+        # It seems that it takes at least two minutes before a newly published version
+        # becomes available in the NPM registry. We wait before starting the image builds.
+        name: Wait For Package Registry
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 2 # timeout for a single attempt
+          max_attempts: 3
+          retry_wait_seconds: 60 # wait between retries
+          command: cd ${{ matrix.image-name }} && npm i --dry-run
+      - 
+        name: Build image with node version.
+        uses: docker/build-push-action@v2
+        if: ${{ env.RELEASE_TAG == 'latest' }}
+        with:
+          context: ./${{ matrix.image-name }}
+          file: ./${{ matrix.image-name }}/Dockerfile
+          load: true
+          tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }},apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
+      -
+        name: Build Image without node version tag (other than latest version tag) 
+        uses: docker/build-push-action@v2
+        if: ${{ env.RELEASE_TAG != 'latest' }}
+        with:
+          context: ./${{ matrix.image-name }}
+          file: ./${{ matrix.image-name }}/Dockerfile
+          load: true
+          tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
+ 
+      -
+        name: Test image
+        run: docker run apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
+      -
+        name: Test image with node version tag
+        if: ${{ matrix.image-name == 'node' }}
+        run: docker run apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Push Image without node version tag
+        run: docker push apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
+      -
+        name: Push Image with node version tag
+        if: ${{ env.RELEASE_TAG == 'latest' }}
+        run: docker push apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}

--- a/.github/workflows/release-playwright.yml
+++ b/.github/workflows/release-playwright.yml
@@ -1,4 +1,4 @@
-name: Release Images
+name: Release Playwright images
 
 on:
   workflow_dispatch:
@@ -15,10 +15,6 @@ on:
       playwright_version:
         description: 'Playwright version (e.g.: 1.7.1)'
         required: true
-      node_version:
-        description: 'NodeJs version for image actor-node'
-        required: false
-        default: '14'
 
   repository_dispatch:
     types: [ build-images ]
@@ -28,7 +24,6 @@ env:
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
   PUPPETEER_VERSION: ${{ github.event.inputs.puppeteer_version || github.event.client_payload.puppeteer_version }}
   PLAYWRIGHT_VERSION: ${{ github.event.inputs.playwright_version || github.event.client_payload.playwright_version }}
-  NODE_VERSION: ${{ github.event.client_payload.node_version || github.event.inputs.node_version }}
 
 jobs:
   # Build master images that are not dependent on existing builds.
@@ -36,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image-name: [node, node-puppeteer-chrome, node-playwright, node-playwright-chrome, node-playwright-firefox, node-playwright-webkit]
+        image-name: [node-playwright, node-playwright-chrome, node-playwright-firefox, node-playwright-webkit]
     steps:
       -
         name: Checkout
@@ -62,58 +57,31 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 60 # wait between retries
           command: cd ${{ matrix.image-name }} && npm i --dry-run
-      -
-        name: Build Image with puppeteer version
-        id: docker_build
-        uses: docker/build-push-action@v2
-        if: ${{ env.RELEASE_TAG =='latest' && contains(matrix.image-name, 'puppeteer') }}
-        with:
-          context: ./${{ matrix.image-name }}
-          file: ./${{ matrix.image-name }}/Dockerfile
-          load: true
-          tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }},apify/actor-${{ matrix.image-name }}:${{ env.PUPPETEER_VERSION }}
       - 
-        name: Build Image with playwright version
+        name: Build image with playwright version
         uses: docker/build-push-action@v2
-        if: ${{ env.RELEASE_TAG =='latest' && contains(matrix.image-name, 'playwright') }}
+        if: ${{ env.RELEASE_TAG == 'latest' }}
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
           load: true
           tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }},apify/actor-${{ matrix.image-name }}:${{ env.PLAYWRIGHT_VERSION }}
       - 
-        name: Build Image without automation library version tag
+        name: Build image without playwright version (other than latest version tag)
         uses: docker/build-push-action@v2
-        if: ${{ matrix.image-name != 'node' && env.RELEASE_TAG !='latest'}}
+        if: ${{env.RELEASE_TAG != 'latest'}}
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
           load: true
           tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
-      - 
-        name: Build image with node version.
-        uses: docker/build-push-action@v2
-        if: ${{ matrix.image-name == 'node' }}
-        with:
-          context: ./${{ matrix.image-name }}
-          file: ./${{ matrix.image-name }}/Dockerfile
-          load: true
-          tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }},apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
       -
-        name: Test Image
+        name: Test image
         run: docker run apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
       -
-        name: Test Image with puppeteer version tag
-        if: ${{ env.RELEASE_TAG =='latest' && contains(matrix.image-name, 'puppeteer') }}
-        run: docker run apify/actor-${{ matrix.image-name }}:${{ env.PUPPETEER_VERSION }}
-      -
-        name: Test Image with playwright version tag
-        if: ${{ env.RELEASE_TAG =='latest' && contains(matrix.image-name, 'playwright') }}
+        name: Test image with playwright version tag
+        if: ${{ env.RELEASE_TAG == 'latest'}}
         run: docker run apify/actor-${{ matrix.image-name }}:${{ env.PLAYWRIGHT_VERSION }}
-      -
-        name: Test Image with node version tag
-        if: ${{ matrix.image-name == 'node' }}
-        run: docker run apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v1
@@ -121,13 +89,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Push Image without automation library version tag
+        name: Push image without automation library version tag
         run: docker push apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
       -
-        name: Push Image with puppeteer version tag
-        if: ${{ env.RELEASE_TAG =='latest' && contains(matrix.image-name, 'puppeteer') }}
-        run: docker push apify/actor-${{ matrix.image-name }}:${{ env.PUPPETEER_VERSION }}
-      -
-        name: Push Image with playwirght version tag
-        if: ${{ env.RELEASE_TAG =='latest' && contains(matrix.image-name, 'playwright') }}
+        name: Push image with playwright version tag
+        if: ${{ env.RELEASE_TAG == 'latest' }}
         run: docker push apify/actor-${{ matrix.image-name }}:${{ env.PLAYWRIGHT_VERSION }}

--- a/.github/workflows/release-puppeteer.yml
+++ b/.github/workflows/release-puppeteer.yml
@@ -1,0 +1,94 @@
+name: Release puppeteer image
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag for the images (e.g.: beta)'
+        required: true
+      apify_version:
+        description: 'Apify SDK version (e.g.: ^1.0.0)'
+        required: true
+      puppeteer_version:
+        description: 'Puppeteer version (e.g.: 5.5.0)'
+        required: true
+
+  repository_dispatch:
+    types: [ build-images ]
+
+env:
+  RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag }}
+  APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
+  PUPPETEER_VERSION: ${{ github.event.inputs.puppeteer_version || github.event.client_payload.puppeteer_version }}
+
+jobs:
+  # Build master images that are not dependent on existing builds.
+  build-main:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image-name: [node-puppeteer-chrome]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Set Dependency Versions
+        run: |
+          cd ${{ matrix.image-name }}
+          node ../.github/scripts/set-dependency-versions.js
+      -
+        # It seems that it takes at least two minutes before a newly published version
+        # becomes available in the NPM registry. We wait before starting the image builds.
+        name: Wait For Package Registry
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 2 # timeout for a single attempt
+          max_attempts: 3
+          retry_wait_seconds: 60 # wait between retries
+          command: cd ${{ matrix.image-name }} && npm i --dry-run
+      -
+        name: Build image with puppeteer version
+        id: docker_build
+        uses: docker/build-push-action@v2
+        if: ${{ env.RELEASE_TAG == 'latest' }}
+        with:
+          context: ./${{ matrix.image-name }}
+          file: ./${{ matrix.image-name }}/Dockerfile
+          load: true
+          tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }},apify/actor-${{ matrix.image-name }}:${{ env.PUPPETEER_VERSION }}
+      - 
+        name: Build image without puppeteer version (other than latest version tag) 
+        uses: docker/build-push-action@v2
+        if: ${{ env.RELEASE_TAG != 'latest' }}
+        with:
+          context: ./${{ matrix.image-name }}
+          file: ./${{ matrix.image-name }}/Dockerfile
+          load: true
+          tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
+      - 
+        name: Test image
+        run: docker run apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
+      -
+        name: Test image with puppeteer version tag
+        if: ${{ env.RELEASE_TAG == 'latest' }}
+        run: docker run apify/actor-${{ matrix.image-name }}:${{ env.PUPPETEER_VERSION }}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Push image without automation library version tag
+        run: docker push apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
+      -
+        name: Push image with puppeteer version tag
+        if: ${{ env.RELEASE_TAG == 'latest'  }}
+        run: docker push apify/actor-${{ matrix.image-name }}:${{ env.PUPPETEER_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
       playwright_version:
         description: 'Playwright version (e.g.: 1.7.1)'
         required: true
+      node_version:
+        description: 'NodeJs version for image actor-node'
+        required: false
+        default: '14'
 
   repository_dispatch:
     types: [ build-images ]
@@ -24,6 +28,7 @@ env:
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
   PUPPETEER_VERSION: ${{ github.event.inputs.puppeteer_version || github.event.client_payload.puppeteer_version }}
   PLAYWRIGHT_VERSION: ${{ github.event.inputs.playwright_version || github.event.client_payload.playwright_version }}
+  NODE_VERSION: ${{ github.event.client_payload.node_version || github.event.inputs.node_version }}
 
 jobs:
   # Build master images that are not dependent on existing builds.
@@ -79,12 +84,21 @@ jobs:
       - 
         name: Build Image without automation library version tag
         uses: docker/build-push-action@v2
-        if: ${{ !contains(matrix.image-name, 'puppeteer') && !contains(matrix.image-name, 'playwright') || env.RELEASE_TAG !='latest'}}
+        if: ${{ matrix.image-name != node && env.RELEASE_TAG !='latest'}}
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
           load: true
           tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
+      - 
+        name: Build image with node version.
+        uses: docker/build-push-action@v2
+        if: ${{ matrix.image-name == node }}
+        with:
+          context: ./${{ matrix.image-name }}
+          file: ./${{ matrix.image-name }}/Dockerfile
+          load: true
+          tags: apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }},apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
       -
         name: Test Image
         run: docker run apify/actor-${{ matrix.image-name }}:${{ env.RELEASE_TAG }}
@@ -96,6 +110,10 @@ jobs:
         name: Test Image with playwright version tag
         if: ${{ env.RELEASE_TAG =='latest' && contains(matrix.image-name, 'playwright') }}
         run: docker run apify/actor-${{ matrix.image-name }}:${{ env.PLAYWRIGHT_VERSION }}
+      -
+        name: Test Image with node version tag
+        if: ${{ matrix.image-name == node }}
+        run: docker run apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
       - 
         name: Build Image without automation library version tag
         uses: docker/build-push-action@v2
-        if: ${{ matrix.image-name != node && env.RELEASE_TAG !='latest'}}
+        if: ${{ matrix.image-name != 'node' && env.RELEASE_TAG !='latest'}}
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
@@ -93,7 +93,7 @@ jobs:
       - 
         name: Build image with node version.
         uses: docker/build-push-action@v2
-        if: ${{ matrix.image-name == node }}
+        if: ${{ matrix.image-name == 'node' }}
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
@@ -112,7 +112,7 @@ jobs:
         run: docker run apify/actor-${{ matrix.image-name }}:${{ env.PLAYWRIGHT_VERSION }}
       -
         name: Test Image with node version tag
-        if: ${{ matrix.image-name == node }}
+        if: ${{ matrix.image-name == 'node' }}
         run: docker run apify/actor-${{ matrix.image-name }}:${{ env.NODE_VERSION }}
       -
         name: Login to DockerHub

--- a/node-basic/Dockerfile
+++ b/node-basic/Dockerfile
@@ -1,5 +1,7 @@
-# Image is based on Node.js 10.X
-FROM node:12.18-alpine
+# Node 14 as default
+
+ARG VERSION=14 
+FROM node:${VERSION}-alpine
 
 LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors"
 

--- a/node-basic/Dockerfile
+++ b/node-basic/Dockerfile
@@ -1,7 +1,7 @@
 # Node 14 as default
 
-ARG VERSION=14 
-FROM node:${VERSION}-alpine
+ARG NODE_VERSION=14 
+FROM node:${NODE_VERSION}-alpine
 
 LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors"
 


### PR DESCRIPTION
We need to find a way how to simplify the workflows - this is becoming a mess. I would suggest splitting the workflow into 3 workflows - release puppeteer images, release playwright images. release node images.