### PR TITLE
Playwright firefox - added missing ca certificates dependency

### DIFF
--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -3,6 +3,7 @@ FROM node:14-buster-slim
 LABEL maintainer="support@apify.com" Description="Base image for Apify actors using Firefox"
 # Install Firefox dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     fonts-noto-color-emoji \
     libdbus-glib-1-2 \
     libxt6 \


### PR DESCRIPTION
Due to this missing dependency developers are unable to install from the GitHub repository. The issue was only with this particular image - I have tested others and they work as expected.