### PR TITLE
feat: do not remove yarn

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,12 +1,9 @@
 # Node 14 as default
 
-ARG NODE_VERSION=14 
+ARG NODE_VERSION=14
 FROM node:${NODE_VERSION}-alpine
 
 LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors"
-
-# Remove yarn, it's not needed
-RUN rm -rf /opt/yarn /usr/local/bin/yarn /usr/local/bin/yarnpkg
 
 # Create app directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
I tested it locally using `docker inspect` and it seems that the `RUN` command has no effect on size, as both images with and without it are exactly the same size 🤷‍♂️ 

<img width="821" alt="image" src="https://user-images.githubusercontent.com/23726914/119323304-d75c8c80-bc7e-11eb-849f-dfd77c7e21bb.png">

Closes: #54 