### PR TITLE
chore: Disable warnings about outdated pip

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,7 +1,7 @@
 # Use the specified Python version, fallback to 3.7 as default
 
 ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}-alpine
+FROM python:${PYTHON_VERSION}
 
 LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors written in Python"
 
@@ -21,6 +21,9 @@ RUN pip install --upgrade pip
 
 # Disable warnings about outdated pip
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Preinstall the latest versions of setuptools and wheel for faster package installs
+RUN pip install --upgrade setuptools wheel
 
 # Install the specified Python Client version
 ARG APIFY_CLIENT_VERSION


### PR DESCRIPTION
During builds of actors using the Python actor image, pip is complaining that it is outdated even if only a new patch version was released, which is pretty annoying. Pip is pretty stable these days, there's usually no need to update it, so I just added an env var to disable the warnings to the actor image Dockerfile, which should trickle down to all the actors using this image. If the users need to update pip for some reason, they can do it easily on their own in the actor Dockerfile.