### PR TITLE
feat: Update Python actor image Dockerfile

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,7 +1,7 @@
 # Use the specified Python version, fallback to 3.7 as default
 
 ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}-alpine
+FROM python:${PYTHON_VERSION}
 
 LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors written in Python"
 
@@ -16,8 +16,14 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+# Disable warnings about outdated pip
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
 # Upgrade pip before installing anything else first
 RUN pip install --upgrade pip
+
+# Preinstall the latest versions of setuptools and wheel for faster package installs
+RUN pip install --upgrade setuptools wheel
 
 # Install the specified Python Client version
 ARG APIFY_CLIENT_VERSION


### PR DESCRIPTION
Use the default version of the Python base image, because `numpy` can't be installed on the alpine versions.

Disable warnings about outdated `pip`.

Preinstall `setuptools` and `wheel` by default for faster package installs for users.