### PR TITLE
fix: attempt to disable GPU rendering when testing

### DIFF
--- a/node-playwright/main.js
+++ b/node-playwright/main.js
@@ -38,7 +38,7 @@ Apify.main(async () => {
     await testChrome({ headless: true })
 
     // Try to use full Chrome with XVFB
-    await testChrome({ headless: false })
+    await testChrome({ headless: false, args: [ '--disable-gpu' ] })
 
     // Test that "ps" command is available, sometimes it was missing in official Node builds
     await Apify.getMemoryInfo();


### PR DESCRIPTION
It's weird that it crashes only on Node.js 14 & 15. 16 passes without any errors. The test passes locally (on docker) though 🤔 