### PR TITLE
fix: make docker images build again

### DIFF
--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -49,7 +49,7 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config --global set update-notifier false \
+    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -25,6 +25,9 @@ RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser
 
+# Globally disable the update-notifier.
+RUN npm config --global set update-notifier false
+
 # Run everything after as non-privileged user.
 USER myuser
 WORKDIR /home/myuser
@@ -49,7 +52,6 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -80,7 +80,7 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config --global set update-notifier false \
+    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -59,6 +59,9 @@ RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser
 
+# Globally disable the update-notifier.
+RUN npm config --global set update-notifier false
+
 # Run everything after as non-privileged user.
 USER myuser
 WORKDIR /home/myuser
@@ -80,7 +83,6 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -52,6 +52,9 @@ RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser
 
+# Globally disable the update-notifier.
+RUN npm config --global set update-notifier false
+
 # Run everything after as non-privileged user.
 USER myuser
 WORKDIR /home/myuser
@@ -73,7 +76,6 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -73,7 +73,7 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config --global set update-notifier false \
+    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -49,16 +49,16 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
- && npm config --global set update-notifier false \
- && npm install --only=prod --no-optional --no-package-lock --prefer-online \
- && echo "Installed NPM packages:" \
- && (npm list || true) \
- && echo "Node.js version:" \
- && node --version \
- && echo "NPM version:" \
- && npm --version \
- && echo "Google Chrome version:" \
- && bash -c "$APIFY_CHROME_EXECUTABLE_PATH --version"
+    && npm config set update-notifier false \
+    && npm install --only=prod --no-optional --no-package-lock --prefer-online \
+    && echo "Installed NPM packages:" \
+    && (npm list || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version \
+    && echo "Google Chrome version:" \
+    && bash -c "$APIFY_CHROME_EXECUTABLE_PATH --version"
 
 # Set up xvfb
 

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -25,6 +25,9 @@ RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser
 
+# Globally disable the update-notifier.
+RUN npm config --global set update-notifier false
+
 # Run everything after as non-privileged user.
 USER myuser
 WORKDIR /home/myuser
@@ -49,7 +52,6 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -8,14 +8,59 @@ LABEL maintainer="support@apify.com" Description="Base image for Apify actors us
 # This image was inspired by https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
 
 # Install latest Chrome dev packages and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this also installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
+# Note: this also installs the necessary libs to make the bundled version of Chromium that Puppeteer installs work.
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg unzip ca-certificates --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | DEBIAN_FRONTEND=noninteractive apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get purge --auto-remove -y wget unzip \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y procps git libxss1 libxtst6 fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf xvfb \
+    && DEBIAN_FRONTEND=noninteractive apt-get purge --auto-remove -y unzip \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    fonts-freefont-ttf \
+    fonts-ipafont-gothic \
+    fonts-kacst \
+    fonts-liberation \
+    fonts-thai-tlwg \
+    fonts-wqy-zenhei \
+    git \
+    libappindicator3-1 \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libc6 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgbm1 \
+    libgcc1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    libxss1 \
+    libxtst6 \
+    libxtst6 \
+    lsb-release \
+    procps \
+    xdg-utils \
+    xvfb \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -30,14 +75,14 @@ COPY package.json puppeteer_*.js /tmp/chrome-install/
 # Install default dependencies
 RUN npm --quiet set progress=false \
     && npm config --global set update-notifier false \
-    && npm install --only=prod --no-optional --no-package-lock --prefer-online \
-    && npm install --no-save node-fetch@2
+    && npm install --only=prod --no-optional --no-package-lock --prefer-online
 
 # Download the latest Chrome
 RUN node ./puppeteer_download.js
 # Install it
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/chrome.deb \
-    && rm /tmp/chrome.deb
+    && rm /tmp/chrome.deb \
+    && rm -rf /tmp/chrome-install
 
 # Add user so we don't need --no-sandbox.
 RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
@@ -72,7 +117,7 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config --global set update-notifier false \
+    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -67,6 +67,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && mkdir -p /tmp/.X11-unix \
     && chmod 1777 /tmp/.X11-unix
 
+# Globally disable the update-notifier.
+RUN npm config --global set update-notifier false
+
 # Prepare to install the latest Chrome compatible
 RUN mkdir -p /tmp/chrome-install
 WORKDIR /tmp/chrome-install
@@ -74,7 +77,6 @@ COPY package.json puppeteer_*.js /tmp/chrome-install/
 
 # Install default dependencies
 RUN npm --quiet set progress=false \
-    && npm config --global set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online
 
 # Download the latest Chrome
@@ -117,7 +119,6 @@ ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \
-    && npm config set update-notifier false \
     && npm install --only=prod --no-optional --no-package-lock --prefer-online \
     && echo "Installed NPM packages:" \
     && (npm list || true) \

--- a/node-puppeteer-chrome/puppeteer_chrome_test.js
+++ b/node-puppeteer-chrome/puppeteer_chrome_test.js
@@ -20,7 +20,7 @@ const testCompatibility = async (browser) => {
     const chromeVersion = (await browser.version()).match(VERSION_REGEX)[0];
     console.log('Chrome version: %s', chromeVersion);
 
-    const compatibilityVersions = await fetchCompatibilityVersions(browser);
+    const compatibilityVersions = await fetchCompatibilityVersions();
     console.log('Puppeteer compatibility versions are:');
     console.log(compatibilityVersions);
 

--- a/node-puppeteer-chrome/puppeteer_chrome_test.js
+++ b/node-puppeteer-chrome/puppeteer_chrome_test.js
@@ -24,21 +24,26 @@ const testCompatibility = async (browser) => {
     console.log('Puppeteer compatibility versions are:');
     console.log(compatibilityVersions);
 
+    let warnInCaseOfNoMajorVersionFound = false;
+
     // The list is only updated on Chrome releases, not Puppeteer releases, so e.g.
     // when support for Chrome 83 comes with Puppeteer 3.1.0, 3.2.0 will not be listed.
     // We must therefore check if we have Puppeteer >= the latest entry and if that's
     // the case, then it supports the latest entry of Chrome.
-    const matchedCompatibilityVersions = compatibilityVersions.filter(cv => {
+    let matchedCompatibilityVersions = compatibilityVersions.filter(cv => {
         return areVersionsCompatible(cv.pptr, puppeteerVersion);
     });
 
     if (!matchedCompatibilityVersions.length) {
-        throw new Error(`Puppeteer+Chrome test failed: puppeteer version "${puppeteerVersion}" not found`);
+        matchedCompatibilityVersions = compatibilityVersions.slice(0, 1);
+        console.warn(`!!! For Puppeteer ${puppeteerVersion} there was no defined version of Chrome supported. !!!`);
+        console.warn(`This script will check the latest compatible Chrome version that was mentioned for Puppeteer ${matchedCompatibilityVersions[0].pptr} instead.`);
     }
+
     const chromeVersionsCompatibleWithPuppeteer = matchedCompatibilityVersions.map(v => v.chrome);
     const isCompatible = chromeVersionsCompatibleWithPuppeteer.some(chromeVersionCompatibleWithPuppeteer => {
         return areVersionsCompatible(chromeVersionCompatibleWithPuppeteer, chromeVersion)
-    })
+    });
 
     if (!isCompatible) {
         throw new Error(`Puppeteer+Chrome test failed: puppeteer version "${puppeteerVersion}" is not compatible with Chrome version ${chromeVersion}, it's compatible with versions ${chromeVersionsCompatibleWithPuppeteer}`);

--- a/node-puppeteer-chrome/puppeteer_utils.js
+++ b/node-puppeteer-chrome/puppeteer_utils.js
@@ -73,6 +73,9 @@ async function downloadClosestChromeInstaller(versionToCheck) {
         // We found the page, extract the final version and save it
         const rawMatches = rawText.match(VERSION_REGEX);
         const validVersion = rawMatches.filter(item => item.startsWith(relevantPart)).sort()[0];
+
+        console.log(`Found version ${validVersion}, downloading...`);
+
         const downloadUrl = chromeVersionDownloadUrl(`${validVersion}-1`);
 
         const res = await axios.get(downloadUrl, { responseType: 'arraybuffer' });


### PR DESCRIPTION
For puppeteer, me moving the install of chrome to a script made dependencies needed by the bundled Chromium to go missing. I've fixed that, as well as simplified the script as discussed with @B4nan 

For all the images, it seems that trying to set global npm options as the non-privileged user makes it error out (which makes sense), so I've moved that setting to the privileged user. Testing needed to see if it actually disables it (it *should*)