### PR TITLE
feat: Build Python Client images for Python 3.10 as well

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -16,7 +16,7 @@ on:
 env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag }}
   APIFY_CLIENT_VERSION: ${{ github.event.inputs.apify_client_version || github.event.client_payload.apify_client_version }}
-  LATEST_PYTHON: 3.9
+  LATEST_PYTHON: "3.9"
 
 jobs:
   # Build master images that are not dependent on existing builds.
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         image-name: [python]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       -
         name: Checkout


### PR DESCRIPTION
Python 3.10 is out for a month now, we should build actor images with it as well. I'd keep Python 3.9 in the "latest" image for a while, though, at least until one or two bugfix releases are out, and all the libraries support Python 3.10 without issues.