### PR TITLE
fix: correctly sort compatible versions by major, then minor, and otherwise by locale

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node]
-        node-version: [14, 15, 16]
+        node-version: [15, 16, 18]
     steps:
       -
         name: Checkout

--- a/.github/workflows/release-playwright.yml
+++ b/.github/workflows/release-playwright.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node-playwright, node-playwright-chrome, node-playwright-firefox, node-playwright-webkit]
-        node-version: [14, 15, 16]
+        node-version: [15, 16, 18]
     steps:
       -
         name: Checkout

--- a/.github/workflows/release-puppeteer.yml
+++ b/.github/workflows/release-puppeteer.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node-puppeteer-chrome]
-        node-version: [14, 15, 16]
+        node-version: [15, 16, 18]
     steps:
       -
         name: Checkout

--- a/node-puppeteer-chrome/puppeteer_download.js
+++ b/node-puppeteer-chrome/puppeteer_download.js
@@ -16,12 +16,13 @@ async function downloadLatestCompatibleChrome() {
     const compatibleChromeVersion = matchedCompatibilityVersions
         .map((v) => v.chrome)
         .sort((a, b) => {
-            const [majorA, minorA] = a.split('.').map((v) => Number(v));
-            const [majorB, minorB] = b.split('.').map((v) => Number(v));
+            const [majorA, _, minorA, patchA] = a.split('.').map((v) => Number(v));
+            const [majorB, __, minorB, patchB] = b.split('.').map((v) => Number(v));
 
-            if (majorB > majorA) return 1;
-            if (minorB > minorA) return 1;
-            return b.localeCompare(a);
+            const versionANumber = majorA * 10_000 + minorA * 100 + patchA;
+            const versionBNumber = majorB * 10_000 + minorB * 100 + patchB;
+
+            return versionBNumber - versionANumber;
         });
 
     console.warn(`Attempting to find a Chrome installer for versions: ${compatibleChromeVersion.join(', ')}`);

--- a/node-puppeteer-chrome/puppeteer_download.js
+++ b/node-puppeteer-chrome/puppeteer_download.js
@@ -15,7 +15,14 @@ async function downloadLatestCompatibleChrome() {
     // Get all supported Chrome version
     const compatibleChromeVersion = matchedCompatibilityVersions
         .map((v) => v.chrome)
-        .sort((a, b) => b.localeCompare(a));
+        .sort((a, b) => {
+            const [majorA, minorA] = a.split('.').map((v) => Number(v));
+            const [majorB, minorB] = b.split('.').map((v) => Number(v));
+
+            if (majorB > majorA) return 1;
+            if (minorB > minorA) return 1;
+            return b.localeCompare(a);
+        });
 
     console.warn(`Attempting to find a Chrome installer for versions: ${compatibleChromeVersion.join(', ')}`);
 


### PR DESCRIPTION
Should fix the CI bug found in #78 🎉 