### PR TITLE
fix: correct link to the chromium versions file

### DIFF
--- a/node-puppeteer-chrome/puppeteer_utils.js
+++ b/node-puppeteer-chrome/puppeteer_utils.js
@@ -10,11 +10,11 @@ const chromeVersionDownloadUrl = version => `https://dl.google.com/linux/chrome/
  */
 function parseCompatibilityVersions(text) {
     const versionsText = text.substring(
-        text.indexOf('Releases per Chromium Version:'),
-        text.indexOf('* [All releases]')
+        text.indexOf('<!-- version-start -->'),
+        text.indexOf('<!-- version-end -->')
     );
     const versions = versionsText.split('\n')
-        .filter(line => line.includes('* Chromium'))
+        .filter(line => line.includes('- Chromium'))
         .map(line => {
             const vers = line.match(VERSION_REGEX);
             return { chrome: vers[0], pptr: vers[1] }
@@ -37,7 +37,7 @@ function areVersionsCompatible(compatible, actual) {
 }
 
 async function fetchCompatibilityVersions() {
-    const apiResponse = await axios.get('https://raw.githubusercontent.com/GoogleChrome/puppeteer/main/docs/api.md', { responseType: 'text' });
+    const apiResponse = await axios.get('https://raw.githubusercontent.com/GoogleChrome/puppeteer/main/docs/chromium-support.md', { responseType: 'text' });
     const compatibilityVersions = parseCompatibilityVersions(apiResponse.data);
 
     return compatibilityVersions;


### PR DESCRIPTION
Hello.  The `puppeteer_utils.js` file downloads a markdown file from the puppeteer github repo and uses this file to determine compatibility between Chromium and Puppeteer version numbers.  This file was recently moved (from `docs/api.md` to `docs/chromium_support.md`), and as a result the `puppeteer_utils.js` file broke.

This PR fixes `puppeteer_utils.js` to point to the new location.  It also updates the parsing code to reflect some changes to the contents of the file.

Please let me know if you have any questions about this fix.