### PR TITLE
feat: node 18 support, crawlee and bullseye

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "@apify"
+}

--- a/.github/scripts/set-dependency-versions.js
+++ b/.github/scripts/set-dependency-versions.js
@@ -4,7 +4,8 @@ const PACKAGE_JSON_PATH = './package.json';
 
 // Pull request runs of this script will have an argument passed as true (see Set Dependency Versions steps)
 const DEPENDENCY_VERSIONS = process.argv[process.argv.length - 1] === 'true' ?  {
-    'apify': 'beta',
+    'apify': 'next',
+    'crawlee': 'next',
     'puppeteer': 'latest',
     'playwright': 'latest',
     'playwright-chromium': 'latest',
@@ -12,6 +13,7 @@ const DEPENDENCY_VERSIONS = process.argv[process.argv.length - 1] === 'true' ?  
     'playwright-webkit': 'latest',
 } : {
     'apify': process.env.APIFY_VERSION,
+    'crawlee': process.env.CRAWLEE_VERSION,
     'puppeteer': process.env.PUPPETEER_VERSION,
     'playwright': process.env.PLAYWRIGHT_VERSION || 'latest',
     'playwright-chromium': process.env.PLAYWRIGHT_VERSION || 'latest',

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node]
-        node-version: [14, 15, 16, 18]
+        node-version: [16, 18]
     steps:
       -
         name: Checkout

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -18,6 +18,7 @@ on:
 env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag || 'CI_TEST' }}
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
+  CRAWLEE_VERSION: ${{ github.event.inputs.crawlee_version || github.event.client_payload.crawlee_version }}
   NODE_LATEST: 16
 
 jobs:
@@ -30,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node]
-        node-version: [14, 15, 16]
+        node-version: [14, 15, 16, 18]
     steps:
       -
         name: Checkout

--- a/.github/workflows/release-playwright.yml
+++ b/.github/workflows/release-playwright.yml
@@ -9,6 +9,9 @@ on:
       apify_version:
         description: 'Apify SDK version (e.g.: ^1.0.0)'
         required: true
+      crawlee_version:
+        description: 'Crawlee version (e.g.: ^1.0.0)'
+        required: true
       playwright_version:
         description: 'Playwright version (e.g.: 1.7.1)'
         required: true
@@ -21,6 +24,7 @@ on:
 env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag || 'CI_TEST' }}
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
+  CRAWLEE_VERSION: ${{ github.event.inputs.crawlee_version || github.event.client_payload.crawlee_version }}
   PLAYWRIGHT_VERSION: ${{ github.event.inputs.playwright_version || github.event.client_payload.playwright_version }}
   NODE_LATEST: 16
 
@@ -34,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node-playwright, node-playwright-chrome, node-playwright-firefox, node-playwright-webkit]
-        node-version: [14, 15, 16]
+        node-version: [14, 15, 16, 18]
     steps:
       -
         name: Checkout

--- a/.github/workflows/release-playwright.yml
+++ b/.github/workflows/release-playwright.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node-playwright, node-playwright-chrome, node-playwright-firefox, node-playwright-webkit]
-        node-version: [14, 15, 16, 18]
+        node-version: [16, 18]
     steps:
       -
         name: Checkout

--- a/.github/workflows/release-puppeteer.yml
+++ b/.github/workflows/release-puppeteer.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node-puppeteer-chrome]
-        node-version: [14, 15, 16, 18]
+        node-version: [16, 18]
     steps:
       -
         name: Checkout

--- a/.github/workflows/release-puppeteer.yml
+++ b/.github/workflows/release-puppeteer.yml
@@ -9,6 +9,9 @@ on:
       apify_version:
         description: 'Apify SDK version (e.g.: ^1.0.0)'
         required: true
+      crawlee_version:
+        description: 'Crawlee version (e.g.: ^1.0.0)'
+        required: true
       puppeteer_version:
         description: 'Puppeteer version (e.g.: 5.5.0)'
         required: true
@@ -21,6 +24,7 @@ on:
 env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag || 'CI_TEST' }}
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
+  CRAWLEE_VERSION: ${{ github.event.inputs.crawlee_version || github.event.client_payload.crawlee_version }}
   PUPPETEER_VERSION: ${{ github.event.inputs.puppeteer_version || github.event.client_payload.puppeteer_version }}
   NODE_LATEST: 16
 
@@ -34,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         image-name: [node-puppeteer-chrome]
-        node-version: [14, 15, 16]
+        node-version: [14, 15, 16, 18]
     steps:
       -
         name: Checkout

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=16
-# Use buster to be consistent across node versions.
-FROM node:${NODE_VERSION}-buster-slim
+# Use bullseye to be consistent across node versions.
+FROM node:${NODE_VERSION}-bullseye-slim
 
 LABEL maintainer="support@apify.com" Description="Base image for Apify actors using Chrome"
 
@@ -15,7 +15,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg unzip ca-certificates xvfb --no-install-recommends \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | DEBIAN_FRONTEND=noninteractive apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && sh -c 'echo "deb http://ftp.us.debian.org/debian buster main non-free" >> /etc/apt/sources.list.d/fonts.list' \
+    && sh -c 'echo "deb http://ftp.us.debian.org/debian bullseye main non-free" >> /etc/apt/sources.list.d/fonts.list' \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get purge --auto-remove -y wget unzip \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/node-playwright-chrome/chrome_test.js
+++ b/node-playwright-chrome/chrome_test.js
@@ -1,6 +1,6 @@
-const Apify = require('apify');
+const { launchPlaywright } = require('crawlee');
 
-const testPageLoading = async browser => {
+const testPageLoading = async (browser) => {
     const page = await browser.newPage();
     await page.goto('http://www.example.com');
     const pageTitle = await page.title();
@@ -10,15 +10,16 @@ const testPageLoading = async browser => {
 };
 
 const testChrome = async (launchOptions) => {
-    const launchContext = { useChrome: true, launchOptions }
-
+    const launchContext = { useChrome: true, launchOptions };
 
     console.log(`Testing Playwright with Chrome`, launchContext);
 
-    const browser = await Apify.launchPlaywright(launchContext);
+    const browser = await launchPlaywright(launchContext);
 
     await testPageLoading(browser);
     await browser.close();
 };
 
-module.exports = testChrome;
+module.exports = {
+    testChrome,
+};

--- a/node-playwright-chrome/main.js
+++ b/node-playwright-chrome/main.js
@@ -11,29 +11,29 @@ For more information, see https://docs.apify.com/actors/development/source-code#
 `);
 console.log('Testing Docker image...');
 
-const Apify = require('apify');
-const testChrome = require('./chrome_test');
+const { Actor } = require('apify');
+const { launchPlaywright, getMemoryInfo } = require('crawlee');
+const { testChrome } = require('./chrome_test');
 
-Apify.main(async () => {
+Actor.main(async () => {
     // Sanity test browsers.
     // We need --no-sandbox, because even though the build is running on GitHub, the test is running in Docker.
-    const launchOptions = { headless: true, args: ['--no-sandbox'] }
-    const launchContext = { launchOptions }
+    const launchOptions = { headless: true, args: ['--no-sandbox'] };
+    const launchContext = { launchOptions };
 
-    const browser = await Apify.launchPlaywright(launchContext)
+    const browser = await launchPlaywright(launchContext);
     await browser.close();
 
     // Try to use full Chrome headless
-    await testChrome({ headless: true })
+    await testChrome({ headless: true });
 
     // Try to use full Chrome with XVFB
-    await testChrome({ headless: false })
+    await testChrome({ headless: false });
 
     // Try to use playwright default
-    await testChrome({ executablePath: undefined })
-    await testChrome({ executablePath: process.env.APIFY_DEFAULT_BROWSER_PATH })
+    await testChrome({ executablePath: undefined });
+    await testChrome({ executablePath: process.env.APIFY_DEFAULT_BROWSER_PATH });
 
     // Test that "ps" command is available, sometimes it was missing in official Node builds
-    await Apify.getMemoryInfo();
-
+    await getMemoryInfo();
 });

--- a/node-playwright-chrome/package.json
+++ b/node-playwright-chrome/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "apify": "APIFY_VERSION",
+        "crawlee": "CRAWLEE_VERSION",
         "playwright-chromium": "PLAYWRIGHT_VERSION"
     },
     "repository": {}

--- a/node-playwright-chrome/package.json
+++ b/node-playwright-chrome/package.json
@@ -9,7 +9,8 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "playwright-chromium": "PLAYWRIGHT_VERSION"
+        "playwright-chromium": "PLAYWRIGHT_VERSION",
+        "typescript": "^4.7.4"
     },
     "repository": {}
 }

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -1,10 +1,10 @@
 ARG NODE_VERSION=16
-# Use buster to be consistent across node versions.
-FROM node:${NODE_VERSION}-buster-slim
+# Use bullseye to be consistent across node versions.
+FROM node:${NODE_VERSION}-bullseye-slim
 
 LABEL maintainer="support@apify.com" Description="Base image for Apify actors using Firefox"
 # Install Firefox dependencies + tools
-RUN sh -c 'echo "deb http://ftp.us.debian.org/debian buster main non-free" >> /etc/apt/sources.list.d/fonts.list' \
+RUN sh -c 'echo "deb http://ftp.us.debian.org/debian bullseye main non-free" >> /etc/apt/sources.list.d/fonts.list' \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     # Found this in other images, not sure whether it's needed, it does not come from Playwright deps
@@ -18,47 +18,7 @@ RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
 RUN npm config --global set update-notifier false
 
 # Install all required playwright dependencies for firefox
-# Keep updated from https://github.com/microsoft/playwright/blob/a06b06b82bb6b2d550f12e8b18af298f23a08828/packages/playwright-core/src/server/registry/nativeDeps.ts#L229
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    xvfb \
-    fonts-noto-color-emoji \
-    ttf-unifont \
-    libfontconfig \
-    libfreetype6 \
-    xfonts-cyrillic \
-    xfonts-scalable \
-    fonts-liberation \
-    fonts-ipafont-gothic \
-    fonts-wqy-zenhei \
-    fonts-tlwg-loma-otf \
-    ttf-ubuntu-font-family \
-    ffmpeg \
-    libatk1.0-0 \
-    libcairo-gobject2 \
-    libcairo2 \
-    libdbus-1-3 \
-    libdbus-glib-1-2 \
-    libfontconfig1 \
-    libfreetype6 \
-    libgdk-pixbuf2.0-0 \
-    libglib2.0-0 \
-    libgtk-3-0 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libpangoft2-1.0-0 \
-    libx11-6 \
-    libx11-xcb1 \
-    libxcb-shm0 \
-    libxcb1 \
-    libxcomposite1 \
-    libxcursor1 \
-    libxdamage1 \
-    libxext6 \
-    libxfixes3 \
-    libxi6 \
-    libxrender1 \
-    libxt6 \
-    libxtst6
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_config_ignore_scripts=1 npx playwright install-deps firefox
 
 # Cleanup time
 RUN rm -rf /var/lib/apt/lists/* \

--- a/node-playwright-firefox/firefox_test.js
+++ b/node-playwright-firefox/firefox_test.js
@@ -1,6 +1,6 @@
-const Apify = require('apify');
+const { launchPlaywright } = require('crawlee');
 
-const testPageLoading = async browser => {
+const testPageLoading = async (browser) => {
     const page = await browser.newPage();
     await page.goto('http://www.example.com');
     const pageTitle = await page.title();
@@ -11,13 +11,13 @@ const testPageLoading = async browser => {
 
 const testFirefox = async (launchOptions) => {
     const launchContext = {
-         launcher: require("playwright").firefox,
-         launchOptions,
-         }
+        launcher: require('playwright').firefox,
+        launchOptions,
+    };
 
     console.log(`Testing Playwright with Firefox`, launchOptions);
 
-    const browser = await Apify.launchPlaywright(launchContext);
+    const browser = await launchPlaywright(launchContext);
 
     await testPageLoading(browser);
     await browser.close();

--- a/node-playwright-firefox/main.js
+++ b/node-playwright-firefox/main.js
@@ -11,22 +11,23 @@ For more information, see https://docs.apify.com/actors/development/source-code#
 `);
 console.log('Testing Docker image...');
 
-const Apify = require('apify');
+const { Actor } = require('apify');
+const { getMemoryInfo } = require('crawlee');
 const testFirefox = require('./firefox_test');
 
-Apify.main(async () => {
+Actor.main(async () => {
     // Sanity test browsers.
 
     // Try to use full Firefox headless
-    await testFirefox({ headless: true })
+    await testFirefox({ headless: true });
 
     // Try to use full Firefox with XVFB
-    await testFirefox({ headless: false })
+    await testFirefox({ headless: false });
 
     // Try to use playwright default
-    await testFirefox({ executablePath: undefined })
-    await testFirefox({ executablePath: process.env.APIFY_DEFAULT_BROWSER_PATH })
+    await testFirefox({ executablePath: undefined });
+    await testFirefox({ executablePath: process.env.APIFY_DEFAULT_BROWSER_PATH });
 
     // Test that "ps" command is available, sometimes it was missing in official Node builds
-    await Apify.getMemoryInfo();
+    await getMemoryInfo();
 });

--- a/node-playwright-firefox/package.json
+++ b/node-playwright-firefox/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "apify": "APIFY_VERSION",
+        "crawlee": "CRAWLEE_VERSION",
         "playwright-firefox": "PLAYWRIGHT_VERSION"
     },
     "repository": {}

--- a/node-playwright-firefox/package.json
+++ b/node-playwright-firefox/package.json
@@ -9,7 +9,8 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "playwright-firefox": "PLAYWRIGHT_VERSION"
+        "playwright-firefox": "PLAYWRIGHT_VERSION",
+        "typescript": "^4.7.4"
     },
     "repository": {}
 }

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -10,9 +10,6 @@ RUN apt-get update \
     git \
     procps \
     xvfb \
-    && apt-get clean -y && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /src/*.deb \
     # This is needed to remove an annoying error message when running headful.
     && mkdir -p /tmp/.X11-unix \
     && chmod 1777 /tmp/.X11-unix
@@ -37,6 +34,11 @@ RUN npm config --global set update-notifier false
 
 # Install all required playwright dependencies for webkit
 RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_config_ignore_scripts=1 npx playwright install-deps webkit
+
+# Cleanup apt caches
+RUN apt-get clean -y && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /src/*.deb
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-webkit/main.js
+++ b/node-playwright-webkit/main.js
@@ -11,22 +11,23 @@ For more information, see https://docs.apify.com/actors/development/source-code#
 `);
 console.log('Testing Docker image...');
 
-const Apify = require('apify');
+const { Actor } = require('apify');
+const { getMemoryInfo } = require('crawlee');
 const testWebkit = require('./webkit_test');
 
-Apify.main(async () => {
+Actor.main(async () => {
     // Sanity test browsers.
 
     // Try to use full Webkit headless
-    await testWebkit({ headless: true })
+    await testWebkit({ headless: true });
 
     // Try to use full Webkit with XVFB
-    await testWebkit({ headless: false })
-    
+    await testWebkit({ headless: false });
+
     // Try to use playwright default
-    await testWebkit({ executablePath: undefined })
-    await testWebkit({ executablePath: process.env.APIFY_DEFAULT_BROWSER_PATH })
+    await testWebkit({ executablePath: undefined });
+    await testWebkit({ executablePath: process.env.APIFY_DEFAULT_BROWSER_PATH });
 
     // Test that "ps" command is available, sometimes it was missing in official Node builds
-    await Apify.getMemoryInfo();
+    await getMemoryInfo();
 });

--- a/node-playwright-webkit/package.json
+++ b/node-playwright-webkit/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "apify": "APIFY_VERSION",
+        "crawlee": "CRAWLEE_VERSION",
         "playwright-webkit": "PLAYWRIGHT_VERSION"
     },
     "repository": {}

--- a/node-playwright-webkit/package.json
+++ b/node-playwright-webkit/package.json
@@ -9,7 +9,8 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "playwright-webkit": "PLAYWRIGHT_VERSION"
+        "playwright-webkit": "PLAYWRIGHT_VERSION",
+        "typescript": "^4.7.4"
     },
     "repository": {}
 }

--- a/node-playwright-webkit/webkit_test.js
+++ b/node-playwright-webkit/webkit_test.js
@@ -1,6 +1,6 @@
-const Apify = require('apify');
+const { launchPlaywright } = require('crawlee');
 
-const testPageLoading = async browser => {
+const testPageLoading = async (browser) => {
     const page = await browser.newPage();
     await page.goto('http://www.example.com');
     const pageTitle = await page.title();
@@ -11,13 +11,13 @@ const testPageLoading = async browser => {
 
 const testWebkit = async (launchOptions) => {
     const launchContext = {
-         launcher: require("playwright").webkit,
-         launchOptions,
-         }
+        launcher: require('playwright').webkit,
+        launchOptions,
+    };
 
     console.log(`Testing Playwright with Webkit`, launchOptions);
 
-    const browser = await Apify.launchPlaywright(launchContext);
+    const browser = await launchPlaywright(launchContext);
 
     await testPageLoading(browser);
     await browser.close();

--- a/node-playwright/chrome_test.js
+++ b/node-playwright/chrome_test.js
@@ -1,6 +1,6 @@
-const Apify = require("apify")
+const { launchPlaywright } = require('crawlee');
 
-const testPageLoading = async browser => {
+const testPageLoading = async (browser) => {
     const page = await browser.newPage();
     await page.goto('http://www.example.com');
     const pageTitle = await page.title();
@@ -10,12 +10,11 @@ const testPageLoading = async browser => {
 };
 
 const testChrome = async (launchOptions) => {
-    const launchContext = { useChrome: true, launchOptions }
-
+    const launchContext = { useChrome: true, launchOptions };
 
     console.log(`Testing Playwright with Chrome`, launchContext);
 
-    const browser = await Apify.launchPlaywright(launchContext);
+    const browser = await launchPlaywright(launchContext);
 
     await testPageLoading(browser);
     await browser.close();

--- a/node-playwright/main.js
+++ b/node-playwright/main.js
@@ -11,37 +11,34 @@ For more information, see https://docs.apify.com/actors/development/source-code#
 `);
 console.log('Testing Docker image...');
 
-const Apify = require('apify');
-const playwright = require("playwright")
+const { Actor } = require('apify');
+const { launchPlaywright, getMemoryInfo } = require('crawlee');
+const playwright = require('playwright');
 const { testChrome, testPageLoading } = require('./chrome_test');
 
+Actor.main(async () => {
+    const browsers = ['webkit', 'firefox', 'chromium'];
+    const promisesHeadless = browsers.map(async (browserName) => {
+        const browser = await launchPlaywright({ launcher: playwright[browserName] });
+        return testPageLoading(browser);
+    });
 
-
-Apify.main(async () => {
-    const browsers = ["webkit", "firefox", "chromium"]
-    const promisesHeadless = browsers.map(async browserName => {
-        const browser = await Apify.launchPlaywright({ launcher: playwright[browserName] })
-        return testPageLoading(browser)
-
-    })
-
-    const promisesHeadful = browsers.map(async browserName => {
-        const browser = await Apify.launchPlaywright({ launcher: playwright[browserName], launchOptions: { headless: false } })
-        return testPageLoading(browser)
-
-    })
+    const promisesHeadful = browsers.map(async (browserName) => {
+        const browser = await launchPlaywright({ launcher: playwright[browserName], launchOptions: { headless: false } });
+        return testPageLoading(browser);
+    });
 
     await Promise.all(promisesHeadless);
     await Promise.all(promisesHeadful);
 
     // Try to use full Chrome headless
-    await testChrome({ headless: true })
+    await testChrome({ headless: true });
 
     // Try to use full Chrome with XVFB
-    await testChrome({ headless: false, args: [ '--disable-gpu' ] })
+    await testChrome({ headless: false, args: ['--disable-gpu'] });
 
     // Test that "ps" command is available, sometimes it was missing in official Node builds
-    await Apify.getMemoryInfo();
+    await getMemoryInfo();
 
     console.log('All tests passed!');
 });

--- a/node-playwright/package.json
+++ b/node-playwright/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "apify": "APIFY_VERSION",
+        "crawlee": "CRAWLEE_VERSION",
         "playwright": "PLAYWRIGHT_VERSION"
     },
     "repository": {}

--- a/node-playwright/package.json
+++ b/node-playwright/package.json
@@ -9,7 +9,8 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "playwright": "PLAYWRIGHT_VERSION"
+        "playwright": "PLAYWRIGHT_VERSION",
+        "typescript": "^4.7.4"
     },
     "repository": {}
 }

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -26,6 +26,25 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     fonts-thai-tlwg \
     fonts-wqy-zenhei \
     git \
+    # Extracted from unmet dependency log in run https://github.com/apify/apify-actor-docker/runs/7860053048?check_suite_focus=true
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libgbm1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libxcomposite1 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libu2f-udev \
+    # End of extracted from error log
     libxss1 \
     lsb-release \
     procps \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -26,25 +26,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     fonts-thai-tlwg \
     fonts-wqy-zenhei \
     git \
-    # Extracted from unmet dependency log in run https://github.com/apify/apify-actor-docker/runs/7860053048?check_suite_focus=true
-    libasound2 \
-    libatk-bridge2.0-0 \
-    libatk1.0-0 \
-    libatspi2.0-0 \
-    libcairo2 \
-    libcups2 \
-    libdbus-1-3 \
-    libgbm1 \
-    libglib2.0-0 \
-    libgtk-3-0 \
-    libnspr4 \
-    libnss3 \
-    libpango-1.0-0 \
-    libxcomposite1 \
-    libxkbcommon0 \
-    libxrandr2 \
-    libu2f-udev \
-    # End of extracted from error log
     libxss1 \
     lsb-release \
     procps \
@@ -58,6 +39,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
 
 # Globally disable the update-notifier.
 RUN npm config --global set update-notifier false
+
+# Install the required dependencies of chrome..by using playwright's useful CLI
+RUN PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm_config_ignore_scripts=1 npx playwright install-deps chrome
 
 # Prepare to install the latest Chrome compatible
 RUN mkdir -p /tmp/chrome-install

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -26,40 +26,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     fonts-thai-tlwg \
     fonts-wqy-zenhei \
     git \
-    libappindicator3-1 \
-    libasound2 \
-    libatk-bridge2.0-0 \
-    libatk1.0-0 \
-    libc6 \
-    libcairo2 \
-    libcups2 \
-    libdbus-1-3 \
-    libexpat1 \
-    libfontconfig1 \
-    libgbm1 \
-    libgcc1 \
-    libglib2.0-0 \
-    libgtk-3-0 \
-    libnspr4 \
-    libnss3 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libstdc++6 \
-    libx11-6 \
-    libx11-xcb1 \
-    libxcb1 \
-    libxcomposite1 \
-    libxcursor1 \
-    libxdamage1 \
-    libxext6 \
-    libxfixes3 \
-    libxi6 \
-    libxrandr2 \
-    libxrender1 \
     libxss1 \
-    libxss1 \
-    libxtst6 \
-    libxtst6 \
     lsb-release \
     procps \
     xdg-utils \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -1,7 +1,7 @@
 
 ARG NODE_VERSION=16
-# Use buster to be consistent across node versions.
-FROM node:${NODE_VERSION}-buster-slim
+# Use bullseye to be consistent across node versions.
+FROM node:${NODE_VERSION}-bullseye-slim
 
 LABEL maintainer="support@apify.com" Description="Base image for Apify actors using headless Chrome"
 

--- a/node-puppeteer-chrome/main.js
+++ b/node-puppeteer-chrome/main.js
@@ -11,18 +11,16 @@ For more information, see https://docs.apify.com/actors/development/source-code#
 `);
 console.log('Testing Docker image...');
 
-const Apify = require('apify');
+const { Actor } = require('apify');
+const { launchPuppeteer, getMemoryInfo } = require('crawlee');
 const testPuppeteerChrome = require('./puppeteer_chrome_test');
 
-const isV1 = typeof Apify.launchPlaywright === 'function';
-
-Apify.main(async () => {
+Actor.main(async () => {
     // First, try to open Chromium to see all dependencies are correctly installed
     console.log('Testing Puppeteer with Chromium');
     // We need --no-sandbox, because even though the build is running on GitHub, the test is running in Docker.
     const launchOptions = { headless: true, args: ['--no-sandbox'] };
-    const launchContext = isV1 ? { launchOptions } : launchOptions;
-    const browser1 = await Apify.launchPuppeteer(launchContext);
+    const browser1 = await launchPuppeteer({ launchOptions });
     const page1 = await browser1.newPage();
     await page1.goto('http://www.example.com');
     const pageTitle1 = await page1.title();
@@ -35,7 +33,7 @@ Apify.main(async () => {
     await testPuppeteerChrome();
 
     // Test that "ps" command is available, sometimes it was missing in official Node builds
-    await Apify.getMemoryInfo();
+    await getMemoryInfo();
 
     console.log('... test PASSED');
 });

--- a/node-puppeteer-chrome/package.json
+++ b/node-puppeteer-chrome/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "apify": "APIFY_VERSION",
+        "crawlee": "CRAWLEE_VERSION",
         "puppeteer": "PUPPETEER_VERSION"
     },
     "repository": {}

--- a/node-puppeteer-chrome/package.json
+++ b/node-puppeteer-chrome/package.json
@@ -9,7 +9,8 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "puppeteer": "PUPPETEER_VERSION"
+        "puppeteer": "PUPPETEER_VERSION",
+        "typescript": "^4.7.4"
     },
     "repository": {}
 }

--- a/node-puppeteer-chrome/puppeteer_chrome_test.js
+++ b/node-puppeteer-chrome/puppeteer_chrome_test.js
@@ -1,7 +1,5 @@
-const Apify = require('apify');
+const { launchPuppeteer } = require('crawlee');
 const { puppeteerVersion, VERSION_REGEX, areVersionsCompatible, fetchCompatibilityVersions } = require('./puppeteer_utils');
-
-const isV1 = typeof Apify.launchPlaywright === 'function';
 
 /*
  * This file tests whether Puppeteer is compatible with installed Chrome,
@@ -68,10 +66,9 @@ const testPuppeteerChrome = async () => {
     console.log('Testing Puppeteer with full Chrome');
     // We need --no-sandbox, because even though the build is running on GitHub, the test is running in Docker.
     const launchOptions = { headless: true, args: ['--no-sandbox'] };
-    const launchContext = isV1
-        ? { useChrome: true, launchOptions }
-        : { useChrome: true, ...launchOptions };
-    const browser = await Apify.launchPuppeteer(launchContext);
+    const launchContext = { useChrome: true, launchOptions };
+
+    const browser = await launchPuppeteer(launchContext);
     try {
         await testCompatibility(browser);
         await testPageLoading(browser);

--- a/node-puppeteer-chrome/puppeteer_download.js
+++ b/node-puppeteer-chrome/puppeteer_download.js
@@ -13,7 +13,7 @@ async function downloadLatestCompatibleChrome() {
     });
 
     // Get all supported Chrome version
-    const compatibleChromeVersion = matchedCompatibilityVersions
+    const compatibleChromeVersions = matchedCompatibilityVersions
         .map((v) => v.chrome)
         .sort((a, b) => {
             const [majorA] = a.split('.');
@@ -22,9 +22,9 @@ async function downloadLatestCompatibleChrome() {
             return Number(majorB) - Number(majorA);
         });
 
-    console.warn(`Attempting to find a Chrome installer for versions: ${compatibleChromeVersion.join(', ')}`);
+    console.warn(`Attempting to find a Chrome installer for versions: ${compatibleChromeVersions.join(', ')}`);
 
-    const buffer = await downloadClosestChromeInstaller(compatibleChromeVersion);
+    const buffer = await downloadClosestChromeInstaller(compatibleChromeVersions);
     await writeFile('/tmp/chrome.deb', buffer);
 }
 

--- a/node-puppeteer-chrome/puppeteer_download.js
+++ b/node-puppeteer-chrome/puppeteer_download.js
@@ -15,7 +15,12 @@ async function downloadLatestCompatibleChrome() {
     // Get all supported Chrome version
     const compatibleChromeVersion = matchedCompatibilityVersions
         .map((v) => v.chrome)
-        .sort((a, b) => b.localeCompare(a));
+        .sort((a, b) => {
+            const [majorA] = a.split('.');
+            const [majorB] = b.split('.');
+
+            return Number(majorB) - Number(majorA);
+        });
 
     console.warn(`Attempting to find a Chrome installer for versions: ${compatibleChromeVersion.join(', ')}`);
 

--- a/node-puppeteer-chrome/puppeteer_utils.js
+++ b/node-puppeteer-chrome/puppeteer_utils.js
@@ -10,11 +10,11 @@ const chromeVersionDownloadUrl = (version) => `https://dl.google.com/linux/chrom
  */
 function parseCompatibilityVersions(text) {
     const versionsText = text.substring(
-        text.indexOf('Releases per Chromium Version:'),
-        text.indexOf('* [All releases]'),
+        text.indexOf('<!-- version-start -->'),
+        text.indexOf('<!-- version-end -->'),
     );
     const versions = versionsText.split('\n')
-        .filter((line) => line.includes('* Chromium'))
+        .filter((line) => line.includes('- Chromium'))
         .map((line) => {
             const vers = line.match(VERSION_REGEX);
             return { chrome: vers[0], pptr: vers[1] };
@@ -37,7 +37,7 @@ function areVersionsCompatible(compatible, actual) {
 }
 
 async function fetchCompatibilityVersions() {
-    const apiResponse = await axios.get('https://raw.githubusercontent.com/GoogleChrome/puppeteer/main/docs/api.md', { responseType: 'text' });
+    const apiResponse = await axios.get('https://raw.githubusercontent.com/puppeteer/puppeteer/main/docs/chromium-support.md', { responseType: 'text' });
     const compatibilityVersions = parseCompatibilityVersions(apiResponse.data);
 
     return compatibilityVersions;

--- a/node-puppeteer-chrome/puppeteer_utils.js
+++ b/node-puppeteer-chrome/puppeteer_utils.js
@@ -1,8 +1,8 @@
-const { default: axios} = require('axios')
+const { default: axios } = require('axios');
 const { version: puppeteerVersion } = require('puppeteer/package.json');
 
 const VERSION_REGEX = /([\d.?]+)/g;
-const chromeVersionDownloadUrl = version => `https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}_amd64.deb`;
+const chromeVersionDownloadUrl = (version) => `https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${version}_amd64.deb`;
 
 /**
  * @param {string} text
@@ -11,15 +11,15 @@ const chromeVersionDownloadUrl = version => `https://dl.google.com/linux/chrome/
 function parseCompatibilityVersions(text) {
     const versionsText = text.substring(
         text.indexOf('Releases per Chromium Version:'),
-        text.indexOf('* [All releases]')
+        text.indexOf('* [All releases]'),
     );
     const versions = versionsText.split('\n')
-        .filter(line => line.includes('* Chromium'))
-        .map(line => {
+        .filter((line) => line.includes('* Chromium'))
+        .map((line) => {
             const vers = line.match(VERSION_REGEX);
-            return { chrome: vers[0], pptr: vers[1] }
+            return { chrome: vers[0], pptr: vers[1] };
         });
-    if (versions.length < 5){
+    if (versions.length < 5) {
         throw new Error('Cannot find and parse Puppeteer-Chromium versions from Markdown file.');
     }
     return versions;
@@ -31,8 +31,8 @@ function parseCompatibilityVersions(text) {
  * @returns {boolean}
  */
 function areVersionsCompatible(compatible, actual) {
-    const [compMajor, compMinor] = compatible.split('.').map(n => Number(n));
-    const [actualMajor, actualMinor] = actual.split('.').map(n => Number(n));
+    const [compMajor, compMinor] = compatible.split('.').map((n) => Number(n));
+    const [actualMajor, actualMinor] = actual.split('.').map((n) => Number(n));
     return actualMajor === compMajor && actualMinor >= compMinor;
 }
 
@@ -49,7 +49,7 @@ async function fetchCompatibilityVersions() {
  */
 async function downloadClosestChromeInstaller(versionToCheck) {
     // Get the first 3 parts of the version
-    const relevantParts = versionToCheck.map(item => item.split('.').slice(0, 3).join('.'));
+    const relevantParts = versionToCheck.map((item) => item.split('.').slice(0, 3).join('.'));
 
     const versionsThatDoNotExistYet = new Set();
 
@@ -74,7 +74,7 @@ async function downloadClosestChromeInstaller(versionToCheck) {
 
             // We found the page, extract the final version and save it
             const rawMatches = rawText.match(VERSION_REGEX);
-            const foundVersion = rawMatches.filter(item => item.startsWith(relevantPart)).sort()[0];
+            const foundVersion = rawMatches.filter((item) => item.startsWith(relevantPart)).sort()[0];
 
             console.log(`Attempting to download Chrome installer for version ${foundVersion}`);
 
@@ -106,4 +106,4 @@ module.exports = {
     parseCompatibilityVersions,
     puppeteerVersion,
     VERSION_REGEX,
-}
+};

--- a/node/main.js
+++ b/node/main.js
@@ -12,7 +12,7 @@ For more information, see https://docs.apify.com/actors/development/source-code#
 console.log('Testing Docker image...');
 
 const { Actor } = require('apify');
-const { getMemoryInfo } = require('@crawlee/utils');
+const { getMemoryInfo } = require('crawlee');
 
 Actor.main(async () => {
     // Test that "ps" command is available, sometimes it was missing in official Node builds

--- a/node/main.js
+++ b/node/main.js
@@ -11,11 +11,12 @@ For more information, see https://docs.apify.com/actors/development/source-code#
 `);
 console.log('Testing Docker image...');
 
-const Apify = require('apify');
+const { Actor } = require('apify');
+const { getMemoryInfo } = require('@crawlee/utils');
 
-Apify.main(async () => {
+Actor.main(async () => {
     // Test that "ps" command is available, sometimes it was missing in official Node builds
-    await Apify.getMemoryInfo();
+    await getMemoryInfo();
 
     console.log('... test PASSED');
 });

--- a/node/package.json
+++ b/node/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "apify": "APIFY_VERSION",
+        "crawlee": "CRAWLEE_VERSION",
         "typescript": "^4.7.4"
     },
     "repository": {}

--- a/node/package.json
+++ b/node/package.json
@@ -7,7 +7,8 @@
         "start": "node main.js"
     },
     "dependencies": {
-        "apify": "APIFY_VERSION"
+        "apify": "APIFY_VERSION",
+        "typescript": "^4.7.4"
     },
     "repository": {}
 }


### PR DESCRIPTION
- Adds images for nodejs 18
- Upgrades all images that use debian to debian 11 bullseye (also means latest playwright works in them natively)
- updated all the test code to crawlee as well as adds it as a dependency to all images
- Closes #79 