### PR TITLE
feat: preload recognized intermediate TLS certificates for Firefox

### DIFF
--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -8,7 +8,16 @@ RUN sh -c 'echo "deb http://ftp.us.debian.org/debian bullseye main non-free" >> 
     && DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     # Found this in other images, not sure whether it's needed, it does not come from Playwright deps
-    procps
+    procps \
+    # The following packages are needed for the intermediate certificates to work in Firefox.
+    ca-certificates \
+    jq \
+    wget \
+    p11-kit
+
+COPY ./register_intermediate_certs.sh ./register_intermediate_certs.sh
+RUN chmod +x ./register_intermediate_certs.sh \
+    && ./register_intermediate_certs.sh
 
 RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
@@ -66,6 +75,10 @@ RUN mv ./node_modules/playwright-firefox ./node_modules/playwright && rm -rf ./n
 
 # Prevent installing of browsers by future `npm install`.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD 1
+
+# Overrides the dynamic library used by Firefox to determine trusted root certificates with p11-kit-trust.so, which loads the system certificates.
+RUN rm $PLAYWRIGHT_BROWSERS_PATH/firefox-*/firefox/libnssckbi.so
+RUN ln -s /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so $(ls -d $PLAYWRIGHT_BROWSERS_PATH/firefox-*)/firefox/libnssckbi.so
 
 # We should you the autodisplay detection as suggested here: https://github.com/microsoft/playwright/issues/2728#issuecomment-678083619
 ENV DISPLAY=:99

--- a/node-playwright-firefox/register_intermediate_certs.sh
+++ b/node-playwright-firefox/register_intermediate_certs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+FILENAMES=$(wget -O - https://firefox.settings.services.mozilla.com/v1/buckets/security-state/collections/intermediates/records | jq -r '.data[].attachment.location')
+
+mkdir -p /usr/local/share/ca-certificates/firefox
+
+wget -P "/usr/local/share/ca-certificates/firefox/" -i <(echo $FILENAMES | tr ' ' '\n' | sed -e 's/^/https:\/\/firefox-settings-attachments.cdn.mozilla.net\//g')
+
+for f in /usr/local/share/ca-certificates/firefox/*.pem; do
+    mv -- "$f" "${f%.pem}.crt"
+done
+
+chmod 644 /usr/local/share/ca-certificates/firefox/*.crt
+chmod 755 /usr/local/share/ca-certificates/firefox
+
+update-ca-certificates

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -13,7 +13,16 @@ RUN apt-get purge -yq nodejs
 RUN apt-get update && apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     apt-get install -y nodejs \
+    # The following packages are needed for the intermediate certificates to work in Firefox.
+    ca-certificates \
+    jq \
+    wget \
+    p11-kit \
     && apt-get clean -y && apt-get autoremove -y
+
+COPY ./register_intermediate_certs.sh ./register_intermediate_certs.sh
+RUN chmod +x ./register_intermediate_certs.sh \
+    && ./register_intermediate_certs.sh
 
 # Disable chrome auto updates, based on https://support.google.com/chrome/a/answer/9052345
 RUN mkdir -p /etc/default && echo 'repo_add_once=false' > /etc/default/google-chrome
@@ -67,6 +76,10 @@ RUN npm --quiet set progress=false \
     && npm --version \
     && echo "Google Chrome version:" \
     && bash -c "$APIFY_CHROME_EXECUTABLE_PATH --version"
+
+# Overrides the dynamic library used by Firefox to determine trusted root certificates with p11-kit-trust.so, which loads the system certificates.
+RUN rm $PLAYWRIGHT_BROWSERS_PATH/firefox-*/firefox/libnssckbi.so
+RUN ln -s /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so $(ls -d $PLAYWRIGHT_BROWSERS_PATH/firefox-*)/firefox/libnssckbi.so
 
 # Set up xvfb
 

--- a/node-playwright/register_intermediate_certs.sh
+++ b/node-playwright/register_intermediate_certs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+FILENAMES=$(wget -O - https://firefox.settings.services.mozilla.com/v1/buckets/security-state/collections/intermediates/records | jq -r '.data[].attachment.location')
+
+mkdir -p /usr/local/share/ca-certificates/firefox
+
+wget -P "/usr/local/share/ca-certificates/firefox/" -i <(echo $FILENAMES | tr ' ' '\n' | sed -e 's/^/https:\/\/firefox-settings-attachments.cdn.mozilla.net\//g')
+
+for f in /usr/local/share/ca-certificates/firefox/*.pem; do
+    mv -- "$f" "${f%.pem}.crt"
+done
+
+chmod 644 /usr/local/share/ca-certificates/firefox/*.crt
+chmod 755 /usr/local/share/ca-certificates/firefox
+
+update-ca-certificates


### PR DESCRIPTION
Emulates the regular Firefox behaviour by preloading recognized TLS intermediate certificates into the Docker image and setting  Firefox to utilize those.

Original issue [here](https://github.com/apify-projects/store-website-content-crawler/issues/78#issuecomment-1545901677).
> ![obrazek](https://private-user-images.githubusercontent.com/61918049/238005747-c10158f6-cdd1-489e-8419-1f4297055131.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJrZXkxIiwiZXhwIjoxNjg0MTY4NDA5LCJuYmYiOjE2ODQxNjgxMDksInBhdGgiOiIvNjE5MTgwNDkvMjM4MDA1NzQ3LWMxMDE1OGY2LWNkZDEtNDg5ZS04NDE5LTFmNDI5NzA1NTEzMS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBSVdOSllBWDRDU1ZFSDUzQSUyRjIwMjMwNTE1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDIzMDUxNVQxNjI4MjlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01N2M1Y2JkNmJhMDFhNDM1MmYyOWJjODI1NmU0YWE0MGYwYTliYWRjYzdlZTcxMDFmODNmMGUwZTNjZmFlYmE1JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.4EolGyoIOQ6epoAL6-a8UF-dFIHvSxSe6AgZ84G9gJc)
> 
> The server has misconfigured TLS settings - Firefox requires(¹) the server to send the entire certificate chain (all the way up to a recognized self-signed root CA certificate). Some other HTTP clients (incl. Chromium-based browsers) are not as pedantic with the certificate chain, allowing the user to access even this misconfigured page.
> 
> To emulate this behavior, we can probably import all the certificates of the intermediate certification authorities (from [this massive JSON](https://firefox.settings.services.mozilla.com/v1/buckets/security-state/collections/intermediates/records), just how new Firefox versions are doing it, see below) and distribute our Docker image with this extended certificate store.
> 
> ¹ Regular Firefox builds now actually preload the [intermediate CA certs as well](https://blog.mozilla.org/security/2020/11/13/preloading-intermediate-ca-certificates-into-firefox/). The reason why this is failing in the crawler is probably that the Playwright-patched Firefox build does not contact the Mozilla's [Remote Settings](https://wiki.mozilla.org/Firefox/RemoteSettings) infrastructure.
