### PR TITLE
fix: do not move browsers in node-playwright

### DIFF
--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -45,9 +45,6 @@ RUN apt-get update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
-    # Move ms-playwright to user folder
-    && mv /ms-playwright /home/myuser/pw-browsers \
-    \
     # Final cleanup
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
@@ -59,7 +56,8 @@ RUN apt-get update \
 USER myuser
 WORKDIR /home/myuser
 
-ENV PLAYWRIGHT_BROWSERS_PATH=/home/myuser/pw-browsers
+# Point playwright to the preincluded browsers - moving browsers around increases the image size a *lot*
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # Copy source code and xvfb script
 COPY --chown=myuser:myuser package.json main.js chrome_test.js start_xvfb_and_run_cmd.sh /home/myuser/

--- a/python-playwright/Dockerfile
+++ b/python-playwright/Dockerfile
@@ -1,6 +1,6 @@
 # Use the specified Python version
 ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION}
+FROM python:${PYTHON_VERSION}-bullseye
 
 LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors written in Python using playwright"
 

--- a/python-selenium/Dockerfile
+++ b/python-selenium/Dockerfile
@@ -1,6 +1,6 @@
 # Use the specified Python version
 ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION}
+FROM python:${PYTHON_VERSION}-bullseye
 
 LABEL maintainer="support@apify.com" Description="Base image for Apify actors written in Python using Selenium"
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,6 +1,6 @@
 # Use the specified Python version
 ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION}
+FROM python:${PYTHON_VERSION}-bullseye
 
 LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors written in Python"
 


### PR DESCRIPTION
Drops image size from 3.88GB to 2.67GB. This only affects the big node-playwright image, as the other images do not come with browsers bundled in