### PR TITLE
Fix invalid label key (Description -> description)

### DIFF
--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -2,7 +2,7 @@ ARG NODE_VERSION=16
 # Use bullseye to be consistent across node versions.
 FROM node:${NODE_VERSION}-bullseye-slim
 
-LABEL maintainer="support@apify.com" Description="Base image for Apify actors using Chrome"
+LABEL maintainer="support@apify.com" description="Base image for Apify actors using Chrome"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # This image was inspired by https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -2,7 +2,7 @@ ARG NODE_VERSION=16
 # Use bullseye to be consistent across node versions.
 FROM node:${NODE_VERSION}-bullseye-slim
 
-LABEL maintainer="support@apify.com" Description="Base image for Apify actors using Firefox"
+LABEL maintainer="support@apify.com" description="Base image for Apify actors using Firefox"
 ENV DEBIAN_FRONTEND=noninteractive
 
 COPY ./register_intermediate_certs.sh ./register_intermediate_certs.sh

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:jammy
 ARG NODE_VERSION=16
 
-LABEL maintainer="support@apify.com" Description="Base image for Apify actors using Webkit"
+LABEL maintainer="support@apify.com" description="Base image for Apify actors using Webkit"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install WebKit dependencies

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/playwright:${PLAYWRIGHT_VERSION}jammy
 
 ARG NODE_VERSION=16
 
-LABEL maintainer="support@apify.com" Description="Base image for Apify actors using headless Chrome"
+LABEL maintainer="support@apify.com" description="Base image for Apify actors using headless Chrome"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Copy the script for registering intermediate certificates.

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -3,7 +3,7 @@ ARG NODE_VERSION=16
 # Use bullseye to be consistent across node versions.
 FROM node:${NODE_VERSION}-bullseye-slim
 
-LABEL maintainer="support@apify.com" Description="Base image for Apify actors using headless Chrome"
+LABEL maintainer="support@apify.com" description="Base image for Apify actors using headless Chrome"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # This image was inspired by https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=16
 FROM node:${NODE_VERSION}-alpine
 
-LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors"
+LABEL maintainer="support@apify.com" description="Base image for simple Apify actors"
 
 # Globally disable the update-notifier.
 RUN npm config --global set update-notifier false

--- a/python-playwright/Dockerfile
+++ b/python-playwright/Dockerfile
@@ -2,7 +2,7 @@
 ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION}-bullseye
 
-LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors written in Python using playwright"
+LABEL maintainer="support@apify.com" description="Base image for simple Apify actors written in Python using playwright"
 
 # Don't store bytecode, the Python app will be only run once
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/python-selenium/Dockerfile
+++ b/python-selenium/Dockerfile
@@ -2,7 +2,7 @@
 ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION}-bullseye
 
-LABEL maintainer="support@apify.com" Description="Base image for Apify actors written in Python using Selenium"
+LABEL maintainer="support@apify.com" description="Base image for Apify actors written in Python using Selenium"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@
 ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION}-bullseye
 
-LABEL maintainer="support@apify.com" Description="Base image for simple Apify actors written in Python"
+LABEL maintainer="support@apify.com" description="Base image for simple Apify actors written in Python"
 
 # Don't store bytecode, the Python app will be only run once
 ENV PYTHONDONTWRITEBYTECODE 1


### PR DESCRIPTION
According to the Docker docs (https://docs.docker.com/config/labels-custom-metadata/#label-keys-and-values):

> Label keys should begin and end with a lower-case letter and should only contain lower-case alphanumeric characters, the period character (.), and the hyphen character (-). Consecutive periods or hyphens are not allowed.