### PR TITLE
Size reduction of the Python Docker images

### DIFF
--- a/.github/workflows/release-python-playwright.yaml
+++ b/.github/workflows/release-python-playwright.yaml
@@ -10,7 +10,7 @@ on:
         description: 'Apify Python SDK version (e.g.: "1.0.0")'
         required: true
       playwright_version:
-        description: 'Playwright version (e.g.: 1.39.0)'
+        description: 'Playwright version (e.g.: "1.39.0")'
         required: true
 
   repository_dispatch:

--- a/.github/workflows/release-python-selenium.yaml
+++ b/.github/workflows/release-python-selenium.yaml
@@ -9,6 +9,9 @@ on:
       apify_version:
         description: 'Apify Python SDK version (e.g.: "1.0.0")'
         required: true
+      selenium_version:
+        description: 'Selenium version (e.g.: "4.14.0")'
+        required: true
 
   repository_dispatch:
     types: [ build-python-images ]
@@ -18,6 +21,7 @@ on:
 env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag }}
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
+  SELENIUM_VERSION: ${{ github.event.inputs.selenium_version || github.event.client_payload.selenium_version || '4.14.0' }}
   LATEST_PYTHON: "3.11"
 
 jobs:
@@ -68,6 +72,7 @@ jobs:
         env:
           CURRENT_PYTHON: ${{ matrix.python-version }}
           LATEST_PYTHON: ${{ env.LATEST_PYTHON }}
+          FRAMEWORK_VERSION: ${{ env.PLAYWRIGHT_VERSION }}
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           IMAGE_NAME: apify/actor-${{ matrix.image-name }}
         with:
@@ -89,6 +94,7 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             APIFY_VERSION=${{ env.APIFY_VERSION }}
+            SELENIUM_VERSION=${{ env.SELENIUM_VERSION }}
           load: true
           tags: ${{ fromJson(steps.prepare-tags.outputs.result).allTags }}
       -

--- a/python-playwright/Dockerfile
+++ b/python-playwright/Dockerfile
@@ -23,8 +23,14 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Don't buffer output and flush it straight away
 ENV PYTHONUNBUFFERED=1
 
+# Don't use a cache dir
+ENV PIP_NO_CACHE_DIR=1
+
 # Disable warnings about outdated pip
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Disable warnings about running pip as root
+ENV PIP_ROOT_USER_ACTION=ignore
 
 # Set up XVFB
 # We should use the autodisplay detection as suggested here: https://github.com/microsoft/playwright/issues/2728#issuecomment-678083619
@@ -35,7 +41,7 @@ ENV XVFB_WHD=1920x1080x24+32
 # - Upgrades pip to the latest version
 # - Preinstalls the latest versions of setuptools and wheel to improve package installation speed
 # - Installs the specified version of the Apify Python SDK and Playwright
-RUN pip install --upgrade --no-cache-dir --root-user-action ignore \
+RUN pip install --upgrade \
     pip \
     setuptools \
     wheel \

--- a/python-playwright/Dockerfile
+++ b/python-playwright/Dockerfile
@@ -1,47 +1,57 @@
-# Use the specified Python version
+# Get the Python version provided as a build argument
 ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION}-bullseye
 
-LABEL maintainer="support@apify.com" description="Base image for Apify Actors written in Python using Playwright"
+# Extend from the latest Debian and its slim version to keep the image as small as possible
+FROM python:${PYTHON_VERSION}-slim-bullseye
+
+# Add labels to the image to identify it as an Apify Actor
+LABEL maintainer="support@apify.com" \
+      description="Base image for Apify Actors written in Python using Playwright"
+
+# Set the shell to use /bin/bash with specific options (see Hadolint DL4006)
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Get the Apify Python SDK version provided as a build argument
+ARG APIFY_VERSION
+
+# Get the Playwright version provided as a build argument
+ARG PLAYWRIGHT_VERSION
 
 # Don't store bytecode, the Python app will be only run once
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # Don't buffer output and flush it straight away
-ENV PYTHONUNBUFFERED 1
-
-# Create a virtual environment
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
 
 # Disable warnings about outdated pip
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-
-# Upgrade pip before installing anything else first
-RUN pip install --upgrade pip
-
-# Preinstall the latest versions of setuptools and wheel for faster package installs
-RUN pip install --upgrade setuptools wheel
-
-# Create app directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-# Install the specified Apify SDK version and Python Playwright version
-ARG APIFY_VERSION
-ARG PLAYWRIGHT_VERSION
-RUN pip install apify~=${APIFY_VERSION} playwright~=${PLAYWRIGHT_VERSION}
-RUN playwright install-deps
-RUN playwright install
-
-# Next, copy the remaining files and directories with the source code.
-COPY . ./
 
 # Set up XVFB
 # We should use the autodisplay detection as suggested here: https://github.com/microsoft/playwright/issues/2728#issuecomment-678083619
 ENV DISPLAY=:99
 ENV XVFB_WHD=1920x1080x24+32
+
+# This instruction:
+# - Upgrades pip to the latest version
+# - Preinstalls the latest versions of setuptools and wheel to improve package installation speed
+# - Installs the specified version of the Apify Python SDK and Playwright
+RUN pip install --upgrade --no-cache-dir --root-user-action ignore \
+    pip \
+    setuptools \
+    wheel \
+    apify~=${APIFY_VERSION} \
+    playwright~=${PLAYWRIGHT_VERSION}
+
+# Install Playwright and its dependencies
+RUN playwright install-deps && \
+    playwright install
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Copy the dummy source code to the image
+COPY . .
 
 # NOTE: This needs to be compatible with how Apify CLI launches Actors
 ENTRYPOINT ["./start_xvfb_and_run_cmd.sh"]

--- a/python-selenium/Dockerfile
+++ b/python-selenium/Dockerfile
@@ -1,12 +1,37 @@
-# Use the specified Python version
+# Get the Python version provided as a build argument
 ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION}-bullseye
 
-LABEL maintainer="support@apify.com" description="Base image for Apify Actors written in Python using Selenium"
+# Extend from the latest Debian and its slim version to keep the image as small as possible
+FROM python:${PYTHON_VERSION}-slim-bullseye
 
+# Add labels to the image to identify it as an Apify Actor
+LABEL maintainer="support@apify.com" \
+      description="Base image for Apify Actors written in Python using Selenium"
+
+# Set the shell to use /bin/bash with specific options (see Hadolint DL4006)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install curl, firefox, jq, unzip, xvfb and other dependencies
+# Get the Apify Python SDK version provided as a build argument
+ARG APIFY_VERSION
+
+# Get the Selenium version provided as a build argument
+ARG SELENIUM_VERSION
+
+# Don't store bytecode, the Python app will be only run once
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Don't buffer output and flush it straight away
+ENV PYTHONUNBUFFERED=1
+
+# Disable warnings about outdated pip
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Set up XVFB
+# We should use the autodisplay detection as suggested here: https://github.com/microsoft/playwright/issues/2728#issuecomment-678083619
+ENV DISPLAY=:99
+ENV XVFB_WHD=1920x1080x24+32
+
+# Install curl, firefox, jq, unzip, xvfb and dependencies of Chrome and its driver
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -38,53 +63,48 @@ RUN apt-get update && \
         libxt6 \
         libxtst6 \
         unzip \
-        wget \
         xdg-utils \
         xvfb && \
     apt-get autoremove -yqq --purge && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* /var/log/*
 
-# Install gecko driver
-RUN curl -L https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz | tar xz -C /usr/local/bin
+# Download and install Geckodriver
+RUN GECKO_DRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz" && \
+    curl --silent --show-error --location --output /tmp/geckodriver.tar.gz "$GECKO_DRIVER_URL" && \
+    tar --gzip --extract --file=/tmp/geckodriver.tar.gz --directory=/usr/local/bin && \
+    rm -f /tmp/geckodriver.tar.gz
 
-# Install Google Chrome
-RUN CHROME_URL="$(curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -r '.channels.Stable.downloads.chrome[] | select(.platform=="linux64") | .url')" && \
-    curl -sSL -o /tmp/chrome-linux64.zip "$CHROME_URL" && \
+# Download and install Google Chrome
+RUN CHROME_URL="$( \
+        curl --silent --show-error --location https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | \
+        jq -r '.channels.Stable.downloads.chrome[] | select(.platform=="linux64") | .url' \
+    )" && \
+    curl --silent --show-error --location --output /tmp/chrome-linux64.zip "$CHROME_URL" && \
     unzip /tmp/chrome-linux64.zip -d /opt/ && \
     ln -s /opt/chrome-linux64/chrome /usr/bin/google-chrome && \
     ln -s /opt/chrome-linux64/chrome /usr/bin/google-chrome-stable && \
     rm -f /tmp/chrome-linux64.zip
 
-# Install Google Chrome driver
-RUN CHROME_DRIVER_URL="$(curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -r '.channels.Stable.downloads.chromedriver[] | select(.platform=="linux64") | .url')" && \
-    curl -sSL -o /tmp/chromedriver-linux64.zip "$CHROME_DRIVER_URL" && \
+# Download and install Google Chrome driver
+RUN CHROME_DRIVER_URL="$( \
+        curl --silent --show-error --location https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | \
+        jq -r '.channels.Stable.downloads.chromedriver[] | select(.platform=="linux64") | .url' \
+    )" && \
+    curl --silent --show-error --location --output /tmp/chromedriver-linux64.zip "$CHROME_DRIVER_URL" && \
     unzip /tmp/chromedriver-linux64.zip -d /usr/local/bin/ && \
     rm -f /tmp/chromedriver-linux64.zip
 
-# Don't store bytecode, the Python app will be only run once
-ENV PYTHONDONTWRITEBYTECODE 1
-
-# Don't buffer output and flush it straight away
-ENV PYTHONUNBUFFERED 1
-
-# Create a virtual environment
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-# Disable warnings about outdated pip
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-
-# Upgrade pip before installing anything else first
-RUN pip install --upgrade pip
-
-# Preinstall the latest versions of setuptools and wheel for faster package installs
-RUN pip install --upgrade setuptools wheel
-
-# Install the specified Apify SDK for Python version and selenium
-ARG APIFY_VERSION
-RUN pip install apify~=${APIFY_VERSION} selenium
+# This instruction:
+# - Upgrades pip to the latest version
+# - Preinstalls the latest versions of setuptools and wheel to improve package installation speed
+# - Installs the specified version of the Apify Python SDK and Selenium
+RUN pip install --upgrade --no-cache-dir --root-user-action ignore \
+    pip \
+    setuptools \
+    wheel \
+    apify~=${APIFY_VERSION} \
+    selenium~=${SELENIUM_VERSION}
 
 # Create app directory
 RUN mkdir -p /usr/src/app
@@ -92,11 +112,6 @@ WORKDIR /usr/src/app
 
 # Copy the dummy source code to the image
 COPY . .
-
-# Set up XVFB
-# We should use the autodisplay detection as suggested here: https://github.com/microsoft/playwright/issues/2728#issuecomment-678083619
-ENV DISPLAY=:99
-ENV XVFB_WHD=1920x1080x24+32
 
 # NOTE: This needs to be compatible with how Apify CLI launches Actors
 ENTRYPOINT ["./start_xvfb_and_run_cmd.sh"]

--- a/python-selenium/Dockerfile
+++ b/python-selenium/Dockerfile
@@ -23,8 +23,14 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Don't buffer output and flush it straight away
 ENV PYTHONUNBUFFERED=1
 
+# Don't use a cache dir
+ENV PIP_NO_CACHE_DIR=1
+
 # Disable warnings about outdated pip
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Disable warnings about running pip as root
+ENV PIP_ROOT_USER_ACTION=ignore
 
 # Set up XVFB
 # We should use the autodisplay detection as suggested here: https://github.com/microsoft/playwright/issues/2728#issuecomment-678083619
@@ -99,7 +105,7 @@ RUN CHROME_DRIVER_URL="$( \
 # - Upgrades pip to the latest version
 # - Preinstalls the latest versions of setuptools and wheel to improve package installation speed
 # - Installs the specified version of the Apify Python SDK and Selenium
-RUN pip install --upgrade --no-cache-dir --root-user-action ignore \
+RUN pip install --upgrade \
     pip \
     setuptools \
     wheel \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -20,14 +20,20 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Don't buffer output and flush it straight away
 ENV PYTHONUNBUFFERED=1
 
+# Don't use a cache dir
+ENV PIP_NO_CACHE_DIR=1
+
 # Disable warnings about outdated pip
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Disable warnings about running pip as root
+ENV PIP_ROOT_USER_ACTION=ignore
 
 # This instruction:
 # - Upgrades pip to the latest version
 # - Preinstalls the latest versions of setuptools and wheel to improve package installation speed
 # - Installs the specified version of the Apify Python SDK
-RUN pip install --upgrade --no-cache-dir --root-user-action ignore \
+RUN pip install --upgrade ignore \
     pip \
     setuptools \
     wheel \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,32 +1,37 @@
-# Use the specified Python version
+# Get the Python version provided as a build argument
 ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION}-bullseye
 
-LABEL maintainer="support@apify.com" description="Base image for simple Apify Actors written in Python"
+# Extend from the latest Debian and its slim version to keep the image as small as possible
+FROM python:${PYTHON_VERSION}-slim-bullseye
+
+# Add labels to the image to identify it as an Apify Actor
+LABEL maintainer="support@apify.com" \
+      description="Base image for simple Apify Actors written in Python"
+
+# Set the shell to use /bin/bash with specific options (see Hadolint DL4006)
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Get the Apify Python SDK version provided as a build argument
+ARG APIFY_VERSION
 
 # Don't store bytecode, the Python app will be only run once
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # Don't buffer output and flush it straight away
-ENV PYTHONUNBUFFERED 1
-
-# Create a virtual environment
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
 
 # Disable warnings about outdated pip
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Upgrade pip before installing anything else first
-RUN pip install --upgrade pip
-
-# Preinstall the latest versions of setuptools and wheel for faster package installs
-RUN pip install --upgrade setuptools wheel
-
-# Install the specified Apify SDK for Python version
-ARG APIFY_VERSION
-RUN pip install apify~=${APIFY_VERSION}
+# This instruction:
+# - Upgrades pip to the latest version
+# - Preinstalls the latest versions of setuptools and wheel to improve package installation speed
+# - Installs the specified version of the Apify Python SDK
+RUN pip install --upgrade --no-cache-dir --root-user-action ignore \
+    pip \
+    setuptools \
+    wheel \
+    apify~=${APIFY_VERSION}
 
 # Create app directory
 RUN mkdir -p /usr/src/app
@@ -36,4 +41,4 @@ WORKDIR /usr/src/app
 COPY . .
 
 # Set default startup command, using CMD instead of ENTRYPOINT, to allow manual overriding
-CMD python3 -m src
+CMD ["python3", "-m", "src"]


### PR DESCRIPTION
### Description

- A new build arg `SELENIUM_VERSION` was added to `apify/actor-python-selenium`.
- A slim version of the Python base images was used (containing only a minimum of preinstalled Python & Debian packages).
- `pip install` commands are consolidated together and executed with `--no-cache-dir` and `--root-user-action ignore` (the root warning should be gone).
- `apt install` commands are consolidated together, executed with `--no-install-recommends`, and clean-up steps are added.
- I also structured all the Python Dockerfiles in the same way, added comments, moved `ENV` and `ARG` commands together to the beginning, and followed [hadolint](https://github.com/hadolint/hadolint) recommendations.

### Size reduction

- `apify/actor-python` from 1 GB to 168 MB
- `apify/actor-python-selenium` from 1.94 GB to 1.12 GB
- `apify/actor-python-playwright` from 2.75 GB to 1.9 GB

### Issue

- Closes https://github.com/apify/apify-actor-docker/issues/116