### PR TITLE
Update python base images (3.11 -> 3.12, bullsyeye -> bookworm)

### DIFF
--- a/.github/workflows/release-playwright.yaml
+++ b/.github/workflows/release-playwright.yaml
@@ -16,7 +16,7 @@ on:
         description: "Playwright version (e.g.: 1.7.1) (must not be semver range)"
         required: true
       is_latest_browser_image:
-        description: If this is a release of the latest browser image. This gets autofilled by CI in crawlee
+        description: If this is a release of the latest browser image it gets autofilled by CI in Crawlee
         type: boolean
         default: false
 

--- a/.github/workflows/release-puppeteer.yaml
+++ b/.github/workflows/release-puppeteer.yaml
@@ -16,7 +16,7 @@ on:
         description: "Puppeteer version (e.g.: 5.5.0)"
         required: true
       is_latest_browser_image:
-        description: If this is a release of the latest browser image. This gets autofilled by CI in crawlee
+        description: If this is a release of the latest browser image it gets autofilled by CI in Crawlee
         type: boolean
         default: false
 

--- a/.github/workflows/release-python-playwright.yaml
+++ b/.github/workflows/release-python-playwright.yaml
@@ -21,8 +21,8 @@ on:
 env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag }}
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
-  PLAYWRIGHT_VERSION: ${{ github.event.inputs.playwright_version || github.event.client_payload.playwright_version || '1.39.0' }}
-  LATEST_PYTHON: "3.11"
+  PLAYWRIGHT_VERSION: ${{ github.event.inputs.playwright_version || github.event.client_payload.playwright_version || '1.42.0' }}
+  LATEST_PYTHON: "3.12"
 
 jobs:
   # Build master images that are not dependent on existing builds.

--- a/.github/workflows/release-python-selenium.yaml
+++ b/.github/workflows/release-python-selenium.yaml
@@ -22,7 +22,7 @@ env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag }}
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
   SELENIUM_VERSION: ${{ github.event.inputs.selenium_version || github.event.client_payload.selenium_version || '4.14.0' }}
-  LATEST_PYTHON: "3.11"
+  LATEST_PYTHON: "3.12"
 
 jobs:
   # Build master images that are not dependent on existing builds.

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -18,7 +18,7 @@ on:
 env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag }}
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
-  LATEST_PYTHON: "3.11"
+  LATEST_PYTHON: "3.12"
 
 jobs:
   # Build master images that are not dependent on existing builds.

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
 # Environment values
+# Node
 NODE_VERSION ?= 20
 # Tag must have format: v1.42.0-
 PLAYWRIGHT_VERSION ?= v1.42.0-
 # Tag must have format: 22.6.2
 PUPPETEER_VERSION ?= 22.6.2
 
-ALL_TESTS = test-node test-playwright test-playwright-chrome test-playwright-firefox test-playwright-webkit test-puppeteer-chrome
+# Python
+PYTHON_VERSION ?= 3.12
+# Apify latest version (python does not support the 'latest' tag)
+PYTHON_APIFY_VERSION ?= 1.7.0
+PYTHON_PLAYWRIGHT_VERSION = $(subst v,,$(subst -,,$(PLAYWRIGHT_VERSION)))
+PYTHON_SELENIUM_VERSION ?= 4.14.0
+
+ALL_TESTS = test-node test-playwright test-playwright-chrome test-playwright-firefox test-playwright-webkit test-puppeteer-chrome test-python test-python-playwright test-python-selenium
 
 what-tests:
 	@echo "Available tests:"
@@ -120,4 +128,30 @@ test-puppeteer-chrome:
 	@# Delete docker image
 	docker rmi apify/puppeteer-chrome:local
 
-# TODO: python too
+test-python:
+	@echo "Building python with version $(PYTHON_VERSION) (overwrite using PYTHON_VERSION=XX)"
+
+	docker buildx build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) --build-arg APIFY_VERSION=$(PYTHON_APIFY_VERSION) --file ./python/Dockerfile -t apify/python:local --load ./python
+	docker run --rm -it --platform linux/amd64 apify/python:local
+
+	@# Delete docker image
+	docker rmi apify/python:local
+
+test-python-playwright:
+	@echo "Building python-playwright with version $(PYTHON_VERSION) (overwrite using PYTHON_VERSION=XX)"
+
+	docker buildx build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) --build-arg APIFY_VERSION=$(PYTHON_APIFY_VERSION) --build-arg PLAYWRIGHT_VERSION=$(PYTHON_PLAYWRIGHT_VERSION) --file ./python-playwright/Dockerfile -t apify/python-playwright:local --load ./python-playwright
+	docker run --rm -it --platform linux/amd64 apify/python-playwright:local
+
+	@# Delete docker image
+	docker rmi apify/python-playwright:local
+
+test-python-selenium:
+	@echo "Building python-selenium with version $(PYTHON_VERSION) (overwrite using PYTHON_VERSION=XX)"
+
+	docker buildx build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) --build-arg APIFY_VERSION=$(PYTHON_APIFY_VERSION) --build-arg SELENIUM_VERSION=$(PYTHON_SELENIUM_VERSION) --file ./python-selenium/Dockerfile -t apify/python-selenium:local --load ./python-selenium
+	docker run --rm -it --platform linux/amd64 apify/python-selenium:local
+
+	@# Delete docker image
+	docker rmi apify/python-selenium:local
+

--- a/python-playwright/Dockerfile
+++ b/python-playwright/Dockerfile
@@ -2,7 +2,7 @@
 ARG PYTHON_VERSION
 
 # Extend from the latest Debian and its slim version to keep the image as small as possible
-FROM python:${PYTHON_VERSION}-slim-bullseye
+FROM python:${PYTHON_VERSION}-slim-bookworm
 
 # Add labels to the image to identify it as an Apify Actor
 LABEL maintainer="support@apify.com" \

--- a/python-selenium/Dockerfile
+++ b/python-selenium/Dockerfile
@@ -2,7 +2,7 @@
 ARG PYTHON_VERSION
 
 # Extend from the latest Debian and its slim version to keep the image as small as possible
-FROM python:${PYTHON_VERSION}-slim-bullseye
+FROM python:${PYTHON_VERSION}-slim-bookworm
 
 # Add labels to the image to identify it as an Apify Actor
 LABEL maintainer="support@apify.com" \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@
 ARG PYTHON_VERSION
 
 # Extend from the latest Debian and its slim version to keep the image as small as possible
-FROM python:${PYTHON_VERSION}-slim-bullseye
+FROM python:${PYTHON_VERSION}-slim-bookworm
 
 # Add labels to the image to identify it as an Apify Actor
 LABEL maintainer="support@apify.com" \


### PR DESCRIPTION
- change python version from 3.11 to 3.12
- change python base image from slim-bullseye to slim-bookworm
- add tests for python (for local)

Note test for node `test-playwrigth` is failing at my local but I have not touched it at all. 

```
Testing Docker image...
INFO  System info {"apifyVersion":"3.2.0","apifyClientVersion":"2.9.3","crawleeVersion":"3.9.2","osType":"Linux","nodeVersion":"v20.13.1"}
ERROR Failed to launch browser. Please check the following:
- Try installing the required dependencies by running `npx playwright install --with-deps` (https://playwright.dev/docs/browsers).
```

