### PR TITLE
fix: enforce the same crawlee version for the SDK

### DIFF
--- a/.github/scripts/set-dependency-versions.js
+++ b/.github/scripts/set-dependency-versions.js
@@ -50,13 +50,18 @@ function updateDependencyVersions(pkg, dependencyVersions) {
 }
 
 function updateDependencyVersion(pkg, depName, depVersion) {
-    const { dependencies } = pkg;
-    if (!dependencies) throw new Error('Invalid package.json: Has no dependencies.');
+    if (!pkg.dependencies) throw new Error('Invalid package.json: Has no dependencies.');
     // Only update existing deps, so we don't add Puppeteer where it does not belong.
-    if (dependencies[depName]) {
+    if (pkg.dependencies[depName]) {
         // Enforce version only for dependencies that will be updated.
         if (!depVersion) throw new Error(`Version not provided for dependency: ${depName}`)
         console.log(`Setting dependency: ${depName} to version: ${depVersion}`);
-        dependencies[depName] = depVersion;
+        pkg.dependencies[depName] = depVersion;
+    }
+    if (depName === 'crawlee' && pkg.overrides?.apify) {
+        Object.keys(pkg.overrides.apify).forEach(dep => {
+            console.log(`Setting dependency: ${dep} to version: ${depVersion}`);
+            pkg.overrides.apify[dep] = depVersion;
+        });
     }
 }

--- a/node-playwright-chrome/package.json
+++ b/node-playwright-chrome/package.json
@@ -12,5 +12,12 @@
         "playwright-chromium": "PLAYWRIGHT_VERSION",
         "typescript": "^5.4.3"
     },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "CRAWLEE_VERSION",
+            "@crawlee/types": "CRAWLEE_VERSION",
+            "@crawlee/utils": "CRAWLEE_VERSION"
+        }
+    },
     "repository": {}
 }

--- a/node-playwright-firefox/package.json
+++ b/node-playwright-firefox/package.json
@@ -12,5 +12,12 @@
         "playwright-firefox": "PLAYWRIGHT_VERSION",
         "typescript": "^5.4.3"
     },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "CRAWLEE_VERSION",
+            "@crawlee/types": "CRAWLEE_VERSION",
+            "@crawlee/utils": "CRAWLEE_VERSION"
+        }
+    },
     "repository": {}
 }

--- a/node-playwright-webkit/package.json
+++ b/node-playwright-webkit/package.json
@@ -12,5 +12,12 @@
         "playwright-webkit": "PLAYWRIGHT_VERSION",
         "typescript": "^5.4.3"
     },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "CRAWLEE_VERSION",
+            "@crawlee/types": "CRAWLEE_VERSION",
+            "@crawlee/utils": "CRAWLEE_VERSION"
+        }
+    },
     "repository": {}
 }

--- a/node-playwright/package.json
+++ b/node-playwright/package.json
@@ -12,5 +12,12 @@
         "playwright": "PLAYWRIGHT_VERSION",
         "typescript": "^5.4.3"
     },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "CRAWLEE_VERSION",
+            "@crawlee/types": "CRAWLEE_VERSION",
+            "@crawlee/utils": "CRAWLEE_VERSION"
+        }
+    },
     "repository": {}
 }

--- a/node-puppeteer-chrome/package.json
+++ b/node-puppeteer-chrome/package.json
@@ -12,5 +12,12 @@
         "puppeteer": "PUPPETEER_VERSION",
         "typescript": "^5.4.3"
     },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "CRAWLEE_VERSION",
+            "@crawlee/types": "CRAWLEE_VERSION",
+            "@crawlee/utils": "CRAWLEE_VERSION"
+        }
+    },
     "repository": {}
 }

--- a/node/package.json
+++ b/node/package.json
@@ -11,5 +11,12 @@
         "crawlee": "CRAWLEE_VERSION",
         "typescript": "^5.4.3"
     },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "CRAWLEE_VERSION",
+            "@crawlee/types": "CRAWLEE_VERSION",
+            "@crawlee/utils": "CRAWLEE_VERSION"
+        }
+    },
     "repository": {}
 }


### PR DESCRIPTION
This should fix the [broken beta builds](https://github.com/apify/apify-actor-docker/actions/runs/11180166457/job/31081316323), which triggers the SDK validation of this version mismatch.