### PR TITLE
feat: Build Python 3.13 images, drop 3.8

### DIFF
--- a/.github/workflows/release-python-playwright.yaml
+++ b/.github/workflows/release-python-playwright.yaml
@@ -24,7 +24,7 @@ env:
   # The default Playwright version is set because this workflow is triggered by a Python SDK
   # release where the version is not specified.
   PLAYWRIGHT_VERSION: ${{ github.event.inputs.playwright_version || github.event.client_payload.playwright_version || '1.42.0' }}
-  LATEST_PYTHON: "3.12"
+  LATEST_PYTHON: "3.13"
 
 jobs:
   # Build master images that are not dependent on existing builds.
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         image-name: [python-playwright]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Set default inputs if event is pull request

--- a/.github/workflows/release-python-playwright.yaml
+++ b/.github/workflows/release-python-playwright.yaml
@@ -23,7 +23,7 @@ env:
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
   # The default Playwright version is set because this workflow is triggered by a Python SDK
   # release where the version is not specified.
-  PLAYWRIGHT_VERSION: ${{ github.event.inputs.playwright_version || github.event.client_payload.playwright_version || '1.42.0' }}
+  PLAYWRIGHT_VERSION: ${{ github.event.inputs.playwright_version || github.event.client_payload.playwright_version || '1.48.0' }}
   LATEST_PYTHON: "3.13"
 
 jobs:

--- a/.github/workflows/release-python-selenium.yaml
+++ b/.github/workflows/release-python-selenium.yaml
@@ -24,7 +24,7 @@ env:
   # The default Selenium version is set because this workflow is triggered by a Python SDK
   # release where the version is not specified.
   SELENIUM_VERSION: ${{ github.event.inputs.selenium_version || github.event.client_payload.selenium_version || '4.14.0' }}
-  LATEST_PYTHON: "3.12"
+  LATEST_PYTHON: "3.13"
 
 jobs:
   # Build master images that are not dependent on existing builds.
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         image-name: [python-selenium]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Set default inputs if event is pull request

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -18,7 +18,7 @@ on:
 env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.client_payload.release_tag }}
   APIFY_VERSION: ${{ github.event.inputs.apify_version || github.event.client_payload.apify_version }}
-  LATEST_PYTHON: "3.12"
+  LATEST_PYTHON: "3.13"
 
 jobs:
   # Build master images that are not dependent on existing builds.
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         image-name: [python]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Set default inputs if event is pull request

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PLAYWRIGHT_VERSION ?= v1.42.0-
 PUPPETEER_VERSION ?= 22.6.2
 
 # Python
-PYTHON_VERSION ?= 3.12
+PYTHON_VERSION ?= 3.13
 # Apify latest version (python does not support the 'latest' tag)
 PYTHON_APIFY_VERSION ?= 1.7.0
 PYTHON_PLAYWRIGHT_VERSION = $(subst v,,$(subst -,,$(PLAYWRIGHT_VERSION)))

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Node
 NODE_VERSION ?= 20
 # Tag must have format: v1.42.0-
-PLAYWRIGHT_VERSION ?= v1.42.0-
+PLAYWRIGHT_VERSION ?= v1.48.0-
 # Tag must have format: 22.6.2
 PUPPETEER_VERSION ?= 22.6.2
 


### PR DESCRIPTION
- Python 3.13 released - use it
- Python 3.8 is EOL - drop it
- Playwright up to 1.48.0 uses old version of `greenlet` without Python 3.13 support - update it