### PR TITLE
feat: add script to ensure playwright/puppeteer version in package.json is in sync with docker tag

### DIFF
--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -53,7 +53,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/home/myuser/pw-browsers
 ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 
 # Copy source code and xvfb script
-COPY --chown=myuser:myuser package.json main.js firefox_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
+COPY --chown=myuser:myuser package.json main.js check-playwright-version.mjs firefox_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
 # Tell Node.js this is a production environemnt
 ENV NODE_ENV=production

--- a/node-playwright-camoufox/check-playwright-version.mjs
+++ b/node-playwright-camoufox/check-playwright-version.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const packageJsonPath = join(import.meta.dirname, 'package.json');
+const dockerfilePath = join(import.meta.dirname, 'Dockerfile');
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const dependencyVersion = packageJson.dependencies?.playwright;
+
+if (!dependencyVersion) {
+    // no playwright dependency found in package.json
+    process.exit(0);
+}
+
+if (dependencyVersion.match(/^[\^~]/)) {
+    console.error(`playwright dependency in package.json is not pinned to a specific version. Please pin it to a specific version and use the same version in your Dockerfile base image tag, e.g. ${dependencyVersion.replace(/^[\^~]/, '')}.`);
+    process.exit(1);
+}
+
+const dockerfileContent = readFileSync(dockerfilePath, 'utf8');
+const matches = dockerfileContent.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/ig);
+
+for (const match of matches) {
+    const dockerImageVersion = match.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/i)?.[1];
+
+    if (dockerImageVersion !== dependencyVersion) {
+        console.error(`playwright version in Dockerfile (${dockerImageVersion}) does not match version in package.json (${dependencyVersion})`);
+        process.exit(1);
+    }
+}

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -59,7 +59,7 @@ WORKDIR /home/myuser
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/myuser/pw-browsers
 
 # Copy source code and xvfb script
-COPY --chown=myuser:myuser package.json main.js chrome_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
+COPY --chown=myuser:myuser package.json main.js check-playwright-version.mjs chrome_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
 # Sets path to Chrome executable, this is used by Apify.launchPuppeteer()
 ENV APIFY_CHROME_EXECUTABLE_PATH=/usr/bin/google-chrome

--- a/node-playwright-chrome/check-playwright-version.mjs
+++ b/node-playwright-chrome/check-playwright-version.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const packageJsonPath = join(import.meta.dirname, 'package.json');
+const dockerfilePath = join(import.meta.dirname, 'Dockerfile');
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const dependencyVersion = packageJson.dependencies?.playwright;
+
+if (!dependencyVersion) {
+    // no playwright dependency found in package.json
+    process.exit(0);
+}
+
+if (dependencyVersion.match(/^[\^~]/)) {
+    console.error(`playwright dependency in package.json is not pinned to a specific version. Please pin it to a specific version and use the same version in your Dockerfile base image tag, e.g. ${dependencyVersion.replace(/^[\^~]/, '')}.`);
+    process.exit(1);
+}
+
+const dockerfileContent = readFileSync(dockerfilePath, 'utf8');
+const matches = dockerfileContent.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/ig);
+
+for (const match of matches) {
+    const dockerImageVersion = match.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/i)?.[1];
+
+    if (dockerImageVersion !== dependencyVersion) {
+        console.error(`playwright version in Dockerfile (${dockerImageVersion}) does not match version in package.json (${dependencyVersion})`);
+        process.exit(1);
+    }
+}

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -53,7 +53,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/home/myuser/pw-browsers
 ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 
 # Copy source code and xvfb script
-COPY --chown=myuser:myuser package.json main.js firefox_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
+COPY --chown=myuser:myuser package.json main.js check-playwright-version.mjs firefox_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
 # Tell Node.js this is a production environemnt
 ENV NODE_ENV=production

--- a/node-playwright-firefox/check-playwright-version.mjs
+++ b/node-playwright-firefox/check-playwright-version.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const packageJsonPath = join(import.meta.dirname, 'package.json');
+const dockerfilePath = join(import.meta.dirname, 'Dockerfile');
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const dependencyVersion = packageJson.dependencies?.playwright;
+
+if (!dependencyVersion) {
+    // no playwright dependency found in package.json
+    process.exit(0);
+}
+
+if (dependencyVersion.match(/^[\^~]/)) {
+    console.error(`playwright dependency in package.json is not pinned to a specific version. Please pin it to a specific version and use the same version in your Dockerfile base image tag, e.g. ${dependencyVersion.replace(/^[\^~]/, '')}.`);
+    process.exit(1);
+}
+
+const dockerfileContent = readFileSync(dockerfilePath, 'utf8');
+const matches = dockerfileContent.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/ig);
+
+for (const match of matches) {
+    const dockerImageVersion = match.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/i)?.[1];
+
+    if (dockerImageVersion !== dependencyVersion) {
+        console.error(`playwright version in Dockerfile (${dockerImageVersion}) does not match version in package.json (${dependencyVersion})`);
+        process.exit(1);
+    }
+}

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -50,7 +50,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/home/myuser/pw-browsers
 ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 
 # Copy source code and xvfb script
-COPY --chown=myuser:myuser package.json main.js webkit_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
+COPY --chown=myuser:myuser package.json main.js check-playwright-version.mjs webkit_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
 # Tell Node.js this is a production environemnt
 ENV NODE_ENV=production

--- a/node-playwright-webkit/check-playwright-version.mjs
+++ b/node-playwright-webkit/check-playwright-version.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const packageJsonPath = join(import.meta.dirname, 'package.json');
+const dockerfilePath = join(import.meta.dirname, 'Dockerfile');
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const dependencyVersion = packageJson.dependencies?.playwright;
+
+if (!dependencyVersion) {
+    // no playwright dependency found in package.json
+    process.exit(0);
+}
+
+if (dependencyVersion.match(/^[\^~]/)) {
+    console.error(`playwright dependency in package.json is not pinned to a specific version. Please pin it to a specific version and use the same version in your Dockerfile base image tag, e.g. ${dependencyVersion.replace(/^[\^~]/, '')}.`);
+    process.exit(1);
+}
+
+const dockerfileContent = readFileSync(dockerfilePath, 'utf8');
+const matches = dockerfileContent.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/ig);
+
+for (const match of matches) {
+    const dockerImageVersion = match.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/i)?.[1];
+
+    if (dockerImageVersion !== dependencyVersion) {
+        console.error(`playwright version in Dockerfile (${dockerImageVersion}) does not match version in package.json (${dependencyVersion})`);
+        process.exit(1);
+    }
+}

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -65,7 +65,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 
 # Copy source code and xvfb script
-COPY --chown=myuser:myuser package.json main.js chrome_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
+COPY --chown=myuser:myuser package.json main.js check-playwright-version.mjs chrome_test.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
 # Sets path to Chrome executable, this is used by Apify.launchPuppeteer()
 ENV APIFY_CHROME_EXECUTABLE_PATH=/usr/bin/google-chrome

--- a/node-playwright/check-playwright-version.mjs
+++ b/node-playwright/check-playwright-version.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const packageJsonPath = join(import.meta.dirname, 'package.json');
+const dockerfilePath = join(import.meta.dirname, 'Dockerfile');
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const dependencyVersion = packageJson.dependencies?.playwright;
+
+if (!dependencyVersion) {
+    // no playwright dependency found in package.json
+    process.exit(0);
+}
+
+if (dependencyVersion.match(/^[\^~]/)) {
+    console.error(`playwright dependency in package.json is not pinned to a specific version. Please pin it to a specific version and use the same version in your Dockerfile base image tag, e.g. ${dependencyVersion.replace(/^[\^~]/, '')}.`);
+    process.exit(1);
+}
+
+const dockerfileContent = readFileSync(dockerfilePath, 'utf8');
+const matches = dockerfileContent.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/ig);
+
+for (const match of matches) {
+    const dockerImageVersion = match.match(/FROM\s+.*playwright.*:\d+-(\d+\.\d+\.\d+)/i)?.[1];
+
+    if (dockerImageVersion !== dependencyVersion) {
+        console.error(`playwright version in Dockerfile (${dockerImageVersion}) does not match version in package.json (${dependencyVersion})`);
+        process.exit(1);
+    }
+}

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -62,7 +62,7 @@ USER myuser
 WORKDIR /home/myuser
 
 # Copy source code and xvfb script
-COPY --chown=myuser:myuser package.json main.js puppeteer_*.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
+COPY --chown=myuser:myuser package.json main.js check-puppeteer-version.mjs puppeteer_*.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
 # Uncomment to skip the chromium download when installing puppeteer. If you do,
 # you'll need to launch puppeteer with:

--- a/node-puppeteer-chrome/check-puppeteer-version.mjs
+++ b/node-puppeteer-chrome/check-puppeteer-version.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const packageJsonPath = join(import.meta.dirname, 'package.json');
+const dockerfilePath = join(import.meta.dirname, 'Dockerfile');
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const dependencyVersion = packageJson.dependencies?.puppeteer;
+
+if (!dependencyVersion) {
+    // no puppeteer dependency found in package.json
+    process.exit(0);
+}
+
+if (dependencyVersion.match(/^[\^~]/)) {
+    console.error(`puppeteer dependency in package.json is not pinned to a specific version. Please pin it to a specific version and use the same version in your Dockerfile base image tag, e.g. ${dependencyVersion.replace(/^[\^~]/, '')}.`);
+    process.exit(1);
+}
+
+const dockerfileContent = readFileSync(dockerfilePath, 'utf8');
+const matches = dockerfileContent.match(/FROM\s+.*puppeteer.*:\d+-(\d+\.\d+\.\d+)/ig);
+
+for (const match of matches) {
+    const dockerImageVersion = match.match(/FROM\s+.*puppeteer.*:\d+-(\d+\.\d+\.\d+)/i)?.[1];
+
+    if (dockerImageVersion !== dependencyVersion) {
+        console.error(`puppeteer version in Dockerfile (${dockerImageVersion}) does not match version in package.json (${dependencyVersion})`);
+        process.exit(1);
+    }
+}


### PR DESCRIPTION
This will be used in the pw/pup templates as part of their dockerfile, allowing to pin the versions in the templates. 

The script fails only if it finds pw/pup in the package.json as well as base docker image tag, otherwise exits with 0.

We might also need a script to update those pinned versions in the templates.