### PR TITLE
fix: set path in base image for user installs of tools

### DIFF
--- a/python-playwright/Dockerfile
+++ b/python-playwright/Dockerfile
@@ -61,7 +61,7 @@ RUN apt update \
 
 WORKDIR /usr/src/app
 
-ENV PATH="/usr/src/app/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:/home/myuser/.local/bin:$PATH"
 
 # This instruction:
 # - Upgrades pip to the latest version

--- a/python-selenium/Dockerfile
+++ b/python-selenium/Dockerfile
@@ -109,7 +109,7 @@ RUN CHROME_DRIVER_URL="$( \
 
 WORKDIR /usr/src/app
 
-ENV PATH="/usr/src/app/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:/home/myuser/.local/bin:$PATH"
 
 # This instruction:
 # - Upgrades pip to the latest version

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -48,7 +48,7 @@ RUN apt update && \
 
 WORKDIR /usr/src/app
 
-ENV PATH="/usr/src/app/.local/bin:$PATH"
+ENV PATH="/root/.local/bin:/home/myuser/.local/bin:$PATH"
 
 # This instruction:
 # - Upgrades pip to the latest version


### PR DESCRIPTION
Doesn't hurt to have in base images, and removes the need to have it in user images (and templates)