### PR TITLE
chore: drop node 18

### DIFF
--- a/.github/actions/version-matrix/src/shared/constants.ts
+++ b/.github/actions/version-matrix/src/shared/constants.ts
@@ -14,4 +14,4 @@ export const latestPythonVersion = '3.14';
 /**
  * The version of Node to be considered as the "default" version for the built image tags.
  */
-export const latestNodeVersion = '24';
+export const latestNodeVersion = '22';


### PR DESCRIPTION
Node 18 is EoL since March, and 24 is in Active LTS

I'll add in 26 when it comes out