### PR TITLE
fix: playwright chrome not building as of 1.57.0

### DIFF
--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -88,8 +88,8 @@ RUN npm --quiet set progress=false \
     && echo "Google Chrome version:" \
     && bash -c "$APIFY_CHROME_EXECUTABLE_PATH --version" \
     # symlink the chromium binary to the root folder in order to bypass the versioning and resulting browser launch crashes.
-    && ln -s ${PLAYWRIGHT_BROWSERS_PATH}/chromium-*/chrome-linux/chrome ${PLAYWRIGHT_BROWSERS_PATH}/ \
-    # Playwright allows donwloading only one browser through separate package with same export. So we rename it to just playwright.
+    && ln -s ${PLAYWRIGHT_BROWSERS_PATH}/chromium-*/chrome-linux*/chrome ${PLAYWRIGHT_BROWSERS_PATH}/ \
+    # Playwright allows downloading only one browser through separate package with same export. So we rename it to just playwright.
     && mv ./node_modules/playwright-chromium ./node_modules/playwright && rm -rf ./node_modules/playwright-chromium
 
 ENV APIFY_DEFAULT_BROWSER_PATH=${PLAYWRIGHT_BROWSERS_PATH}/chrome


### PR DESCRIPTION
Because for w/e reason the location is now chrome-linux64