### PR TITLE
fix: pin myuser UID/GID to 990 to prevent drift

### DIFF
--- a/node-phantomjs/Dockerfile
+++ b/node-phantomjs/Dockerfile
@@ -23,7 +23,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get purge --auto-remove -y wget \
  && rm -rf /src/*.deb
 
 # Run everything after as non-privileged user to avoid warnings
-RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
+RUN groupadd -r -g 990 myuser && useradd -r -u 990 -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser
 USER myuser

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     --no-install-recommends \
     \
     # Add user so we don't need --no-sandbox.
-    && groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
+    && groupadd -r -g 990 myuser && useradd -r -u 990 -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser \
     \

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -25,7 +25,7 @@ RUN sh -c 'echo "deb http://ftp.us.debian.org/debian bookworm main non-free" >> 
     && ./register_intermediate_certs.sh \
     \
     # Add user so we don't need --no-sandbox.
-    && groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
+    && groupadd -r -g 990 myuser && useradd -r -u 990 -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser \
     \

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && npm install -g yarn \
     \
     # Add user so we don't need --no-sandbox.
-    && groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
+    && groupadd -r -g 990 myuser && useradd -r -u 990 -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser \
     # Globally disable the update-notifier.

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update \
     && apt install --fix-missing -yq ./google-chrome-stable_current_amd64.deb && rm ./google-chrome-stable_current_amd64.deb \
     \
     # Add user so we don't need --no-sandbox.
-    && groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
+    && groupadd -r -g 990 myuser && useradd -r -u 990 -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser \
     \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
     && apt install --fix-missing -yq ./google-chrome-stable_current_amd64.deb && rm ./google-chrome-stable_current_amd64.deb \
     \
     # Add user so we don't need --no-sandbox.
-    && groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
+    && groupadd -r -g 990 myuser && useradd -r -u 990 -g myuser -G audio,video myuser \
     && mkdir -p /home/myuser/Downloads \
     && chown -R myuser:myuser /home/myuser \
     \


### PR DESCRIPTION
- Pin `myuser` UID and GID to `990` in all 6 Node.js Dockerfiles that create this user
- Previously, `groupadd -r` / `useradd -r` auto-assigned system IDs that could shift between builds when base images add/remove system users (e.g. `messagebus`)
- This caused silent permission breakage on persistent volume mounts 

- closes #287