### PR TITLE
fix(node-images): move typescript to devDependencies

### DIFF
--- a/node-playwright-camoufox/package.json
+++ b/node-playwright-camoufox/package.json
@@ -11,8 +11,10 @@
         "camoufox-js": "CAMOUFOX_VERSION",
         "crawlee": "CRAWLEE_VERSION",
         "impit": "latest",
-        "playwright": "PLAYWRIGHT_VERSION",
-        "typescript": "^5.4.3"
+        "playwright": "PLAYWRIGHT_VERSION"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.2"
     },
     "overrides": {
         "apify": {

--- a/node-playwright-chrome/package.json
+++ b/node-playwright-chrome/package.json
@@ -9,8 +9,10 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "playwright-chromium": "PLAYWRIGHT_VERSION",
-        "typescript": "^5.4.3"
+        "playwright-chromium": "PLAYWRIGHT_VERSION"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.2"
     },
     "overrides": {
         "apify": {

--- a/node-playwright-firefox/package.json
+++ b/node-playwright-firefox/package.json
@@ -9,8 +9,10 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "playwright-firefox": "PLAYWRIGHT_VERSION",
-        "typescript": "^5.4.3"
+        "playwright-firefox": "PLAYWRIGHT_VERSION"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.2"
     },
     "overrides": {
         "apify": {

--- a/node-playwright-webkit/package.json
+++ b/node-playwright-webkit/package.json
@@ -9,8 +9,10 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "playwright-webkit": "PLAYWRIGHT_VERSION",
-        "typescript": "^5.4.3"
+        "playwright-webkit": "PLAYWRIGHT_VERSION"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.2"
     },
     "overrides": {
         "apify": {

--- a/node-playwright/package.json
+++ b/node-playwright/package.json
@@ -9,8 +9,10 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "playwright": "PLAYWRIGHT_VERSION",
-        "typescript": "^5.4.3"
+        "playwright": "PLAYWRIGHT_VERSION"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.2"
     },
     "overrides": {
         "apify": {

--- a/node-puppeteer-chrome/package.json
+++ b/node-puppeteer-chrome/package.json
@@ -9,8 +9,10 @@
     "dependencies": {
         "apify": "APIFY_VERSION",
         "crawlee": "CRAWLEE_VERSION",
-        "puppeteer": "PUPPETEER_VERSION",
-        "typescript": "^5.4.3"
+        "puppeteer": "PUPPETEER_VERSION"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.2"
     },
     "overrides": {
         "apify": {

--- a/node/package.json
+++ b/node/package.json
@@ -8,8 +8,10 @@
     },
     "dependencies": {
         "apify": "APIFY_VERSION",
-        "crawlee": "CRAWLEE_VERSION",
-        "typescript": "^5.4.3"
+        "crawlee": "CRAWLEE_VERSION"
+    },
+    "devDependencies": {
+        "typescript": "^5.9.2"
     },
     "overrides": {
         "apify": {


### PR DESCRIPTION
Typescript was in prod dependencies, which caused it to be installed in node_modules in all final stage images, increasing all build sizes by 5 MB (in my test).

Food for thought: 
- Do we want full crawlee preinstalled?
- Are we updating to the latest version often? Otherwise, it is mostly noise to have it preinstalled.

EDIT: Sorry for confusion. Actually, it makes no sense to move it to devDependencies (I will rework it after we agreee what to do). They are not installed (`--omit=dev`) in the base image. So I would propose to get rid of it completely. I can imagine there are some super weird edge cases that don't do any npm install and depend on this but that should not be a reason to ship TS to everyone's prod stage.

What is the primary reason we include the deps in the base image at all?