### PR TITLE
chore(node): drop Node 20, add Node 26; refactor puppeteer image

### DIFF
--- a/.github/actions/version-matrix/src/shared/constants.ts
+++ b/.github/actions/version-matrix/src/shared/constants.ts
@@ -2,7 +2,7 @@ import { appendFile } from 'node:fs/promises';
 
 export const supportedPythonVersions = ['3.10', '3.11', '3.12', '3.13', '3.14'];
 
-export const supportedNodeVersions = ['20', '22', '24'];
+export const supportedNodeVersions = ['22', '24', '26'];
 
 export const shouldUseLastFive = process.env.SHOULD_USE_LAST_FIVE === 'true';
 

--- a/.github/workflows/release-node-puppeteer.yaml
+++ b/.github/workflows/release-node-puppeteer.yaml
@@ -208,7 +208,9 @@ jobs:
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
-          build-args: NODE_VERSION=${{ matrix.node-version }}
+          build-args: |
+            NODE_VERSION=${{ matrix.node-version }}
+            PUPPETEER_VERSION=${{ matrix.puppeteer-version }}
           platforms: linux/amd64
           provenance: false
           load: true
@@ -232,7 +234,9 @@ jobs:
         with:
           context: ./${{ matrix.image-name }}
           file: ./${{ matrix.image-name }}/Dockerfile
-          build-args: NODE_VERSION=${{ matrix.node-version }}
+          build-args: |
+            NODE_VERSION=${{ matrix.node-version }}
+            PUPPETEER_VERSION=${{ matrix.puppeteer-version }}
           platforms: linux/amd64
           provenance: true
           push: true

--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ test-node-puppeteer-chrome:
 	@# Correct package.json
 	@APIFY_VERSION=latest CRAWLEE_VERSION=latest PUPPETEER_VERSION=$(PUPPETEER_VERSION) node ./scripts/update-package-json.mjs ./node-puppeteer-chrome
 
-	docker buildx build --platform linux/amd64 --build-arg NODE_VERSION=$(NODE_VERSION) --file ./node-puppeteer-chrome/Dockerfile --tag apify/node-puppeteer-chrome:local --output type=docker,oci-mediatypes=true ./node-puppeteer-chrome
+	docker buildx build --platform linux/amd64 --build-arg NODE_VERSION=$(NODE_VERSION) --build-arg PUPPETEER_VERSION=$(PUPPETEER_VERSION) --file ./node-puppeteer-chrome/Dockerfile --tag apify/node-puppeteer-chrome:local --output type=docker,oci-mediatypes=true ./node-puppeteer-chrome
 	docker run --rm -it --platform linux/amd64 apify/node-puppeteer-chrome:local
 
 	@# Restore package.json
@@ -362,7 +362,7 @@ test-node-puppeteer-chrome-arm:
 	@# Correct package.json
 	@APIFY_VERSION=latest CRAWLEE_VERSION=latest PUPPETEER_VERSION=$(PUPPETEER_VERSION) node ./scripts/update-package-json.mjs ./node-puppeteer-chrome
 
-	docker buildx build --platform linux/arm64 --build-arg NODE_VERSION=$(NODE_VERSION) --file ./node-puppeteer-chrome/Dockerfile --tag apify/node-puppeteer-chrome:local --load ./node-puppeteer-chrome
+	docker buildx build --platform linux/arm64 --build-arg NODE_VERSION=$(NODE_VERSION) --build-arg PUPPETEER_VERSION=$(PUPPETEER_VERSION) --file ./node-puppeteer-chrome/Dockerfile --tag apify/node-puppeteer-chrome:local --load ./node-puppeteer-chrome
 	docker run --rm -it --platform linux/arm64 apify/node-puppeteer-chrome:local
 
 	@# Restore package.json

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -67,20 +67,17 @@ RUN apt update \
     \
     # Pre-install the puppeteer-bundled browsers into PUPPETEER_CACHE_DIR.
     # We install puppeteer-core@${PUPPETEER_VERSION} to read its pinned Chrome revisions
-    # (parsing revisions.js as text so it works for both CJS in puppeteer 24 and ESM in puppeteer 25),
-    # then invoke a newer @puppeteer/browsers CLI to actually download.
+    # via the package's public ESM export, then invoke @puppeteer/browsers CLI to actually download.
     # Older puppeteer versions bundle @puppeteer/browsers 2.13.0, which silently fails to extract
-    # Chrome on node 26 (the binary is missing after extraction).
+    # Chrome on node 26 (the binary is missing after extraction), so we always use the latest CLI.
     && cd /tmp \
     && npm init -y --silent > /dev/null \
     && npm install --no-save --no-package-lock --omit=optional puppeteer-core@${PUPPETEER_VERSION} \
-    && REVISIONS_FILE=$(find /tmp/node_modules/puppeteer-core/lib -name revisions.js -not -name "*.map" | head -1) \
-    && CHROME_VERSION=$(grep -E "^[[:space:]]*chrome:" "$REVISIONS_FILE" | sed -E "s/.*['\"]([0-9.]+)['\"].*/\1/") \
-    && CHS_VERSION=$(grep -E "['\"]chrome-headless-shell['\"][[:space:]]*:" "$REVISIONS_FILE" | sed -E "s/.*:[[:space:]]*['\"]([0-9.]+)['\"].*/\1/") \
-    && rm -rf /tmp/node_modules /tmp/package.json /tmp/package-lock.json \
+    && read -r CHROME_VERSION CHS_VERSION < <(node --input-type=module -e "import {PUPPETEER_REVISIONS as r} from 'puppeteer-core'; console.log(r.chrome, r['chrome-headless-shell'])") \
+    && rm -rf /tmp/node_modules /tmp/package*.json \
     && cd / \
-    && npx --yes @puppeteer/browsers@3.0.2 install chrome@${CHROME_VERSION} --path ${PUPPETEER_CACHE_DIR} \
-    && npx --yes @puppeteer/browsers@3.0.2 install chrome-headless-shell@${CHS_VERSION} --path ${PUPPETEER_CACHE_DIR} \
+    && npx --yes @puppeteer/browsers install chrome@${CHROME_VERSION} --path ${PUPPETEER_CACHE_DIR} \
+    && npx --yes @puppeteer/browsers install chrome-headless-shell@${CHS_VERSION} --path ${PUPPETEER_CACHE_DIR} \
     && chmod -R a+rX ${PUPPETEER_CACHE_DIR} \
     \
     # unzip is only needed during browser extraction above; drop it now.

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -2,8 +2,7 @@ ARG NODE_VERSION=22
 # Use trixie to be consistent across node versions.
 FROM --platform=linux/amd64 node:${NODE_VERSION}-trixie-slim
 
-# Version of puppeteer that pins the browser revisions we install below.
-# Must match the puppeteer version in package.json so that the runtime puppeteer finds its expected Chrome revision.
+# Must match the puppeteer version in package.json so the installed Chrome revisions line up with what runtime puppeteer expects.
 ARG PUPPETEER_VERSION
 
 LABEL maintainer="support@apify.com" description="Base image for Apify Actors using headless Chrome"
@@ -24,8 +23,7 @@ ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 # Sets path to Chrome executable, this is used by Apify.launchPuppeteer()
 ENV APIFY_CHROME_EXECUTABLE_PATH=/usr/bin/google-chrome
 
-# Prevent installing of browsers by future `npm install`.
-# PUPPETEER_SKIP_CHROMIUM_DOWNLOAD is the old name (puppeteer <22); PUPPETEER_SKIP_DOWNLOAD is current (puppeteer 22+).
+# Skip browser download during `npm install`. CHROMIUM_DOWNLOAD is the old name (puppeteer <22), kept for back-compat.
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
@@ -65,11 +63,9 @@ RUN apt update \
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -nv \
     && apt install --fix-missing -yq ./google-chrome-stable_current_amd64.deb && rm ./google-chrome-stable_current_amd64.deb \
     \
-    # Pre-install the puppeteer-bundled browsers into PUPPETEER_CACHE_DIR.
-    # We install puppeteer-core@${PUPPETEER_VERSION} to read its pinned Chrome revisions
-    # via the package's public ESM export, then invoke @puppeteer/browsers CLI to actually download.
-    # Older puppeteer versions bundle @puppeteer/browsers 2.13.0, which silently fails to extract
-    # Chrome on node 26 (the binary is missing after extraction), so we always use the latest CLI.
+    # Pre-install browsers into PUPPETEER_CACHE_DIR using the latest @puppeteer/browsers CLI —
+    # puppeteer 24.x bundles 2.13.0, which silently fails to extract Chrome on node 26.
+    # The pinned Chrome revisions come from puppeteer-core's PUPPETEER_REVISIONS export.
     && cd /tmp \
     && npm init -y --silent > /dev/null \
     && npm install --no-save --no-package-lock --omit=optional puppeteer-core@${PUPPETEER_VERSION} \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -69,8 +69,9 @@ WORKDIR /home/myuser
 COPY --chown=myuser:myuser package.json main.js check-puppeteer-version.mjs puppeteer_*.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
 # Skip puppeteer's bundled browser download — we use system Chrome instead.
-# PUPPETEER_SKIP_CHROMIUM_DOWNLOAD was the old name (puppeteer <22); PUPPETEER_SKIP_DOWNLOAD is current.
+# PUPPETEER_SKIP_CHROMIUM_DOWNLOAD is the old name (puppeteer <25); PUPPETEER_SKIP_DOWNLOAD is current (puppeteer 25+).
 ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # Sets path to Chrome executable, this is used by Apify.launchPuppeteer()
 ENV APIFY_CHROME_EXECUTABLE_PATH=/usr/bin/google-chrome

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -68,10 +68,9 @@ WORKDIR /home/myuser
 # Copy source code and xvfb script
 COPY --chown=myuser:myuser package.json main.js check-puppeteer-version.mjs puppeteer_*.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
-# Uncomment to skip the chromium download when installing puppeteer. If you do,
-# you'll need to launch puppeteer with:
-#     browser.launch({executablePath: 'google-chrome'})
-# ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+# Skip puppeteer's bundled browser download — we use system Chrome instead.
+# PUPPETEER_SKIP_CHROMIUM_DOWNLOAD was the old name (puppeteer <22); PUPPETEER_SKIP_DOWNLOAD is current.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 # Sets path to Chrome executable, this is used by Apify.launchPuppeteer()
 ENV APIFY_CHROME_EXECUTABLE_PATH=/usr/bin/google-chrome

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -66,11 +66,21 @@ RUN apt update \
     && apt install --fix-missing -yq ./google-chrome-stable_current_amd64.deb && rm ./google-chrome-stable_current_amd64.deb \
     \
     # Pre-install the puppeteer-bundled browsers into PUPPETEER_CACHE_DIR.
-    # PUPPETEER_SKIP_DOWNLOAD only blocks puppeteer's npm postinstall hook, not the explicit `browsers install` command.
-    # We pin the puppeteer version so the installed Chrome revision matches the one the runtime puppeteer expects.
-    # We install both `chrome` (used when launching with headless: true) and `chrome-headless-shell` (used when launching with headless: 'shell').
-    && npx --yes puppeteer@${PUPPETEER_VERSION} browsers install chrome \
-    && npx --yes puppeteer@${PUPPETEER_VERSION} browsers install chrome-headless-shell \
+    # We install puppeteer-core@${PUPPETEER_VERSION} to read its pinned Chrome revisions
+    # (parsing revisions.js as text so it works for both CJS in puppeteer 24 and ESM in puppeteer 25),
+    # then invoke a newer @puppeteer/browsers CLI to actually download.
+    # Older puppeteer versions bundle @puppeteer/browsers 2.13.0, which silently fails to extract
+    # Chrome on node 26 (the binary is missing after extraction).
+    && cd /tmp \
+    && npm init -y --silent > /dev/null \
+    && npm install --no-save --no-package-lock --omit=optional puppeteer-core@${PUPPETEER_VERSION} \
+    && REVISIONS_FILE=$(find /tmp/node_modules/puppeteer-core/lib -name revisions.js -not -name "*.map" | head -1) \
+    && CHROME_VERSION=$(grep -E "^[[:space:]]*chrome:" "$REVISIONS_FILE" | sed -E "s/.*['\"]([0-9.]+)['\"].*/\1/") \
+    && CHS_VERSION=$(grep -E "['\"]chrome-headless-shell['\"][[:space:]]*:" "$REVISIONS_FILE" | sed -E "s/.*:[[:space:]]*['\"]([0-9.]+)['\"].*/\1/") \
+    && rm -rf /tmp/node_modules /tmp/package.json /tmp/package-lock.json \
+    && cd / \
+    && npx --yes @puppeteer/browsers@3.0.2 install chrome@${CHROME_VERSION} --path ${PUPPETEER_CACHE_DIR} \
+    && npx --yes @puppeteer/browsers@3.0.2 install chrome-headless-shell@${CHS_VERSION} --path ${PUPPETEER_CACHE_DIR} \
     && chmod -R a+rX ${PUPPETEER_CACHE_DIR} \
     \
     # unzip is only needed during browser extraction above; drop it now.

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -2,8 +2,32 @@ ARG NODE_VERSION=22
 # Use trixie to be consistent across node versions.
 FROM --platform=linux/amd64 node:${NODE_VERSION}-trixie-slim
 
+# Version of puppeteer that pins the browser revisions we install below.
+# Must match the puppeteer version in package.json so that the runtime puppeteer finds its expected Chrome revision.
+ARG PUPPETEER_VERSION
+
 LABEL maintainer="support@apify.com" description="Base image for Apify Actors using headless Chrome"
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Set the shell to use /bin/bash with specific options (see Hadolint DL4006)
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set up XVFB
+ENV XVFB_WHD=1920x1080x24+32
+
+# Tells puppeteer where to install and where to find browsers
+ENV PUPPETEER_CACHE_DIR=/puppeteer-browsers
+
+# Tell the crawlee cli that we already have browsers installed, so it skips installing them
+ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
+
+# Sets path to Chrome executable, this is used by Apify.launchPuppeteer()
+ENV APIFY_CHROME_EXECUTABLE_PATH=/usr/bin/google-chrome
+
+# Prevent installing of browsers by future `npm install`.
+# PUPPETEER_SKIP_CHROMIUM_DOWNLOAD is the old name (puppeteer <22); PUPPETEER_SKIP_DOWNLOAD is current (puppeteer 22+).
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # This image was inspired by https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
 
@@ -19,7 +43,6 @@ RUN apt update \
     && sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list' \
     && sh -c 'echo "deb http://ftp.us.debian.org/debian trixie main non-free" >> /etc/apt/sources.list.d/fonts.list' \
     && apt update \
-    && apt purge --auto-remove -y unzip \
     && apt install -y \
     fonts-freefont-ttf \
     fonts-ipafont-gothic \
@@ -41,6 +64,17 @@ RUN apt update \
     # Install chrome
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -nv \
     && apt install --fix-missing -yq ./google-chrome-stable_current_amd64.deb && rm ./google-chrome-stable_current_amd64.deb \
+    \
+    # Pre-install the puppeteer-bundled browsers into PUPPETEER_CACHE_DIR.
+    # PUPPETEER_SKIP_DOWNLOAD only blocks puppeteer's npm postinstall hook, not the explicit `browsers install` command.
+    # We pin the puppeteer version so the installed Chrome revision matches the one the runtime puppeteer expects.
+    # We install both `chrome` (used when launching with headless: true) and `chrome-headless-shell` (used when launching with headless: 'shell').
+    && npx --yes puppeteer@${PUPPETEER_VERSION} browsers install chrome \
+    && npx --yes puppeteer@${PUPPETEER_VERSION} browsers install chrome-headless-shell \
+    && chmod -R a+rX ${PUPPETEER_CACHE_DIR} \
+    \
+    # unzip is only needed during browser extraction above; drop it now.
+    && apt purge --auto-remove -y unzip \
     \
     # Add user so we don't need --no-sandbox.
     && groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
@@ -68,17 +102,6 @@ WORKDIR /home/myuser
 # Copy source code and xvfb script
 COPY --chown=myuser:myuser package.json main.js check-puppeteer-version.mjs puppeteer_*.js start_xvfb_and_run_cmd.sh new_xvfb_run_cmd.sh xvfb-entrypoint.sh /home/myuser/
 
-# Skip puppeteer's bundled browser download — we use system Chrome instead.
-# PUPPETEER_SKIP_CHROMIUM_DOWNLOAD is the old name (puppeteer <25); PUPPETEER_SKIP_DOWNLOAD is current (puppeteer 25+).
-ENV PUPPETEER_SKIP_DOWNLOAD=true
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-
-# Sets path to Chrome executable, this is used by Apify.launchPuppeteer()
-ENV APIFY_CHROME_EXECUTABLE_PATH=/usr/bin/google-chrome
-
-# Tell the crawlee cli that we already have browers installed, so it skips installing them
-ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
-
 # Tell Node.js this is a production environemnt
 ENV NODE_ENV=production
 
@@ -99,9 +122,6 @@ RUN npm --quiet set progress=false \
     && npm --version \
     && echo "Google Chrome version:" \
     && bash -c "$APIFY_CHROME_EXECUTABLE_PATH --version"
-
-# Set up xvfb
-ENV XVFB_WHD=1920x1080x24+32
 
 # The entrypoint script will be the one handling the CMD passed in, and will always wrap it into xvfb-run
 ENTRYPOINT ["/home/myuser/xvfb-entrypoint.sh"]


### PR DESCRIPTION
## Summary

- Drop Node 20 (EOL April 2026) and add Node 26 to `supportedNodeVersions`
- Refactor the node-puppeteer-chrome image to mirror the playwright image's browser-install pattern:
  - Pre-install `chrome` and `chrome-headless-shell` into `PUPPETEER_CACHE_DIR=/puppeteer-browsers` during the system-deps step
  - Set `PUPPETEER_SKIP_DOWNLOAD` / `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` so the user-stage `npm install` doesn't re-download
  - Pin `npx puppeteer@${PUPPETEER_VERSION}` so each image's Chrome revision matches the runtime puppeteer's expected revision (workflow passes `PUPPETEER_VERSION` as a build-arg)
  - `unzip` is purged after browser extraction (it was being purged before, which broke puppeteer 25's `chrome-headless-shell` install)

## Test plan

- [x] Local: built and ran the puppeteer-chrome image against all 5 matrix versions (24.41.0, 24.42.0, 24.43.0, 24.43.1, 25.0.2) — all pass `test PASSED`
- [ ] CI: green on all node × puppeteer combinations