### PR TITLE
ci: Update `signed-commit` action

### DIFF
--- a/.github/workflows/release-node-playwright.yaml
+++ b/.github/workflows/release-node-playwright.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Commit updated matrix
         id: commit
         if: github.event_name != 'pull_request'
-        uses: apify/actions/signed-commit@v1.1.2
+        uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "chore(docker): update ${{ env.RELEASE_TAG || 'latest' }} node:playwright cache"
           add: ./.github/actions/version-matrix/data/*.json

--- a/.github/workflows/release-node-puppeteer.yaml
+++ b/.github/workflows/release-node-puppeteer.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Commit updated matrix
         id: commit
         if: github.event_name != 'pull_request'
-        uses: apify/actions/signed-commit@v1.1.2
+        uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "chore(docker): update ${{ env.RELEASE_TAG || 'latest' }} node:puppeteer-chrome cache"
           add: ./.github/actions/version-matrix/data/*.json

--- a/.github/workflows/release-node.yaml
+++ b/.github/workflows/release-node.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Commit updated matrix
         id: commit
         if: github.event_name != 'pull_request'
-        uses: apify/actions/signed-commit@v1.1.2
+        uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "chore(docker): update ${{ env.RELEASE_TAG || 'latest' }} node:normal cache"
           add: ./.github/actions/version-matrix/data/*.json

--- a/.github/workflows/release-python-playwright.yaml
+++ b/.github/workflows/release-python-playwright.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Commit updated matrix
         id: commit
         if: github.event_name != 'pull_request'
-        uses: apify/actions/signed-commit@v1.1.2
+        uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "chore(docker): update ${{ env.RELEASE_TAG || 'latest' }} python:playwright cache"
           add: ./.github/actions/version-matrix/data/*.json

--- a/.github/workflows/release-python-selenium.yaml
+++ b/.github/workflows/release-python-selenium.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Commit updated matrix
         id: commit
         if: github.event_name != 'pull_request'
-        uses: apify/actions/signed-commit@v1.1.2
+        uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "chore(docker): update ${{ env.RELEASE_TAG || 'latest' }} python:selenium cache"
           add: ./.github/actions/version-matrix/data/*.json

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Commit updated matrix
         id: commit
         if: github.event_name != 'pull_request'
-        uses: apify/actions/signed-commit@v1.1.2
+        uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "chore(docker): update ${{ env.RELEASE_TAG || 'latest' }} python:normal cache"
           add: ./.github/actions/version-matrix/data/*.json

--- a/.github/workflows/update-certificates.yaml
+++ b/.github/workflows/update-certificates.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Commit certificate changes
         if: steps.check-changes.outputs.has_changes == 'true'
-        uses: apify/actions/signed-commit@v1.1.2
+        uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "chore(certificates): update Firefox intermediate certificates"
           add: ./certificates/


### PR DESCRIPTION
The `signed-commit` action did not handle retries on concurrent updates well, causing some of the release workflows to silently not commit the updated changes. The new version [fixes](https://github.com/apify/actions/pull/22) this.