### PR TITLE
feat: add Football Goal Email Notifier Actor

### DIFF
--- a/goal-notifier-actor/.actor/actor.json
+++ b/goal-notifier-actor/.actor/actor.json
@@ -1,0 +1,29 @@
+{
+    "actorSpecification": 1,
+    "name": "goal-notifier",
+    "title": "Football Goal Email Notifier",
+    "description": "Watches a live football match (e.g. Belgium vs Spain) and emails you the moment anyone scores a goal.",
+    "version": "0.1",
+    "meta": {
+        "templateId": "custom"
+    },
+    "input": "./input_schema.json",
+    "dockerfile": "../Dockerfile",
+    "storages": {
+        "dataset": {
+            "actorSpecification": 1,
+            "title": "Goal events",
+            "views": {
+                "goals": {
+                    "title": "Goals scored",
+                    "transformation": {
+                        "fields": ["minute", "team", "scorer", "assist", "detail", "score", "notifiedAt"]
+                    },
+                    "display": {
+                        "component": "table"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/goal-notifier-actor/.actor/input_schema.json
+++ b/goal-notifier-actor/.actor/input_schema.json
@@ -1,0 +1,71 @@
+{
+    "title": "Goal notifier input",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "rapidApiKey": {
+            "title": "RapidAPI key (API-Football)",
+            "type": "string",
+            "description": "Your RapidAPI key for the API-Football (api-football-v1) endpoint. Get one at https://rapidapi.com/api-sports/api/api-football.",
+            "editor": "textfield",
+            "isSecret": true
+        },
+        "notificationEmail": {
+            "title": "Notification email",
+            "type": "string",
+            "description": "Email address that will receive a message for every goal.",
+            "editor": "textfield",
+            "prefill": "marcel.rebro@apify.com"
+        },
+        "homeTeam": {
+            "title": "Home team",
+            "type": "string",
+            "description": "Team name to match (case-insensitive substring). Used to auto-resolve the fixture when no Fixture ID is given.",
+            "editor": "textfield",
+            "prefill": "Belgium"
+        },
+        "awayTeam": {
+            "title": "Away team",
+            "type": "string",
+            "description": "The other team name to match (case-insensitive substring).",
+            "editor": "textfield",
+            "prefill": "Spain"
+        },
+        "matchDate": {
+            "title": "Match date (UTC, YYYY-MM-DD)",
+            "type": "string",
+            "description": "Date the match takes place, in UTC. Leave empty to search today's fixtures. Ignored when Fixture ID is set.",
+            "editor": "textfield"
+        },
+        "fixtureId": {
+            "title": "Fixture ID (optional override)",
+            "type": "integer",
+            "description": "API-Football fixture ID. If provided, team/date auto-resolution is skipped. Most reliable option.",
+            "editor": "number"
+        },
+        "pollIntervalSecs": {
+            "title": "Poll interval (seconds)",
+            "type": "integer",
+            "description": "How often to check the match for new goals.",
+            "editor": "number",
+            "default": 30,
+            "minimum": 15,
+            "maximum": 600
+        },
+        "notifyOnKickoffAndFullTime": {
+            "title": "Also email on kickoff & full-time",
+            "type": "boolean",
+            "description": "Send an extra email when the match kicks off and when it finishes.",
+            "default": true
+        },
+        "maxRuntimeSecs": {
+            "title": "Max runtime (seconds)",
+            "type": "integer",
+            "description": "Hard stop for the watcher, in case the match status never reaches a finished state.",
+            "editor": "number",
+            "default": 18000,
+            "minimum": 60
+        }
+    },
+    "required": ["rapidApiKey", "notificationEmail"]
+}

--- a/goal-notifier-actor/.dockerignore
+++ b/goal-notifier-actor/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+node_modules
+storage
+apify_storage
+crawlee_storage
+.DS_Store
+*.log

--- a/goal-notifier-actor/Dockerfile
+++ b/goal-notifier-actor/Dockerfile
@@ -1,0 +1,20 @@
+# Base image maintained in this repo (apify/apify-actor-docker).
+FROM apify/actor-node:22
+
+# Copy just the manifests first so the npm install layer is cached
+# unless dependencies actually change.
+COPY package*.json ./
+
+RUN npm --quiet set progress=false \
+    && npm install --omit=dev --omit=optional \
+    && echo "Installed npm packages:" \
+    && (npm list --omit=dev --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "npm version:" \
+    && npm --version
+
+# Copy the rest of the source.
+COPY . ./
+
+CMD ["npm", "start", "--silent"]

--- a/goal-notifier-actor/README.md
+++ b/goal-notifier-actor/README.md
@@ -1,0 +1,64 @@
+# ⚽ Football Goal Email Notifier
+
+An [Apify Actor](https://docs.apify.com/actor) that watches a single live football match and
+**emails you the moment anyone scores** — one email per goal, plus optional kickoff and full-time
+messages. Built to answer requests like *"tell me whenever someone scores in the Belgium vs Spain
+match."*
+
+- **Data source:** [API-Football](https://www.api-football.com/) via RapidAPI (live goal events with
+  scorer, minute, assist and goal type).
+- **Email:** the [`apify/send-mail`](https://apify.com/apify/send-mail) Actor — no SMTP credentials
+  needed, it sends through your Apify account.
+
+## Input
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `rapidApiKey` | ✅ | – | Your RapidAPI key for `api-football-v1`. |
+| `notificationEmail` | ✅ | – | Address that receives the goal emails. |
+| `homeTeam` | | `Belgium` | Team name to match (substring, case-insensitive). |
+| `awayTeam` | | `Spain` | The other team name. |
+| `matchDate` | | today (UTC) | `YYYY-MM-DD` date used to auto-find the fixture. |
+| `fixtureId` | | – | API-Football fixture ID. If set, skips team/date lookup (most reliable). |
+| `pollIntervalSecs` | | `30` | How often to check for new goals. |
+| `notifyOnKickoffAndFullTime` | | `true` | Also email at kickoff and full-time. |
+| `maxRuntimeSecs` | | `18000` | Safety stop (5 h) if the match never reaches a finished status. |
+
+### How the fixture is found
+
+If you pass a `fixtureId`, that's used directly. Otherwise the Actor searches all fixtures on
+`matchDate` (defaulting to today, UTC) and picks the one where the two team names both match. Because
+international team names can vary ("Belgium" vs "Belgium U21"), **passing an explicit `fixtureId` is
+the most reliable option** — you can find it with a quick API-Football `/fixtures` query.
+
+## How it works
+
+1. Resolves the fixture to watch.
+2. Polls `/fixtures` (status + score) and `/fixtures/events` (goal events) every `pollIntervalSecs`.
+3. Diffs the goal events against the ones it has already seen; each new goal triggers a
+   `pushData` record and an email via `apify/send-mail`.
+4. Stops when the match status becomes `FT`/`AET`/`PEN` (finished), is abandoned, or the runtime
+   cap is hit.
+
+State (seen goals, kickoff flag) is persisted to the default key-value store, so a platform
+migration or restart won't re-send goals you were already notified about.
+
+## Running it
+
+On the Apify platform: set the inputs and **Start**. Kick it off shortly before the match — while
+the fixture status is `NS` (not started) the Actor simply waits and polls.
+
+Locally with the [Apify CLI](https://docs.apify.com/cli):
+
+```bash
+cd goal-notifier-actor
+apify run -p
+```
+
+> Note: emails are sent through the `apify/send-mail` Actor, so email delivery requires running on
+> the Apify platform (or a local run authenticated with `apify login`).
+
+## Output
+
+Every goal is stored as a dataset row (`minute`, `team`, `scorer`, `assist`, `detail`, `score`,
+`notifiedAt`), viewable under the **Goals scored** dataset view.

--- a/goal-notifier-actor/package.json
+++ b/goal-notifier-actor/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "goal-notifier",
+    "version": "0.1.0",
+    "type": "module",
+    "description": "Apify Actor that emails you whenever anyone scores in a live football match.",
+    "engines": {
+        "node": ">=18"
+    },
+    "dependencies": {
+        "apify": "^3.2.6"
+    },
+    "scripts": {
+        "start": "node src/main.js"
+    },
+    "license": "Apache-2.0"
+}

--- a/goal-notifier-actor/src/main.js
+++ b/goal-notifier-actor/src/main.js
@@ -1,0 +1,210 @@
+import { Actor, log } from 'apify';
+
+// --- API-Football (via RapidAPI) constants ------------------------------------
+const RAPIDAPI_HOST = 'api-football-v1.p.rapidapi.com';
+const API_BASE = `https://${RAPIDAPI_HOST}/v3`;
+
+// Fixture status short-codes, grouped by what they mean for the watcher.
+// See https://www.api-football.com/documentation-v3#tag/Fixtures
+const LIVE_STATUSES = new Set(['1H', '2H', 'HT', 'ET', 'BT', 'P', 'LIVE', 'INT']);
+const FINISHED_STATUSES = new Set(['FT', 'AET', 'PEN']);
+const ABANDONED_STATUSES = new Set(['PST', 'CANC', 'ABD', 'SUSP', 'AWD', 'WO']);
+
+// KV-store key used to survive a migration/restart without re-sending emails.
+const STATE_KEY = 'WATCHER_STATE';
+
+await Actor.init();
+
+const input = (await Actor.getInput()) ?? {};
+const {
+    rapidApiKey,
+    notificationEmail,
+    homeTeam = 'Belgium',
+    awayTeam = 'Spain',
+    matchDate,
+    fixtureId: inputFixtureId,
+    pollIntervalSecs = 30,
+    notifyOnKickoffAndFullTime = true,
+    maxRuntimeSecs = 18000,
+} = input;
+
+if (!rapidApiKey) throw new Error('Missing "rapidApiKey" input. Provide your API-Football RapidAPI key.');
+if (!notificationEmail) throw new Error('Missing "notificationEmail" input.');
+
+/** Small typed wrapper around the API-Football REST endpoint. */
+async function apiFootball(path, searchParams = {}) {
+    const url = new URL(`${API_BASE}${path}`);
+    for (const [key, value] of Object.entries(searchParams)) {
+        if (value !== undefined && value !== null && value !== '') url.searchParams.set(key, value);
+    }
+    const res = await fetch(url, {
+        headers: {
+            'x-rapidapi-key': rapidApiKey,
+            'x-rapidapi-host': RAPIDAPI_HOST,
+        },
+    });
+    if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`API-Football request failed: ${res.status} ${res.statusText} for ${path} — ${body.slice(0, 300)}`);
+    }
+    const json = await res.json();
+    // API-Football reports auth/quota problems in a non-empty `errors` object with HTTP 200.
+    if (json.errors && (Array.isArray(json.errors) ? json.errors.length : Object.keys(json.errors).length)) {
+        throw new Error(`API-Football returned errors: ${JSON.stringify(json.errors)}`);
+    }
+    return json.response ?? [];
+}
+
+/** Resolve the fixture to watch, either from an explicit id or by matching team names on a date. */
+async function resolveFixture() {
+    if (inputFixtureId) {
+        const [fixture] = await apiFootball('/fixtures', { id: inputFixtureId });
+        if (!fixture) throw new Error(`No fixture found for id ${inputFixtureId}.`);
+        return fixture;
+    }
+
+    const date = matchDate || new Date().toISOString().slice(0, 10);
+    log.info(`No fixtureId given — searching fixtures on ${date} for "${homeTeam}" vs "${awayTeam}".`);
+    const fixtures = await apiFootball('/fixtures', { date, timezone: 'UTC' });
+
+    const home = homeTeam.toLowerCase();
+    const away = awayTeam.toLowerCase();
+    const match = fixtures.find((f) => {
+        const names = [f.teams?.home?.name ?? '', f.teams?.away?.name ?? ''].map((n) => n.toLowerCase());
+        const hasHome = names.some((n) => n.includes(home));
+        const hasAway = names.some((n) => n.includes(away));
+        return hasHome && hasAway;
+    });
+
+    if (!match) {
+        throw new Error(
+            `Could not find a "${homeTeam}" vs "${awayTeam}" fixture on ${date}. ` +
+            `Set "matchDate" correctly or pass an explicit "fixtureId".`,
+        );
+    }
+    return match;
+}
+
+/** Stable identity for a goal event so we never notify twice for the same one. */
+function goalKey(ev) {
+    return [ev.time?.elapsed, ev.time?.extra ?? 0, ev.team?.name, ev.player?.name, ev.detail].join('|');
+}
+
+/** True for events that represent an actual goal being scored (not a missed penalty). */
+function isGoal(ev) {
+    return ev.type === 'Goal' && ev.detail !== 'Missed Penalty';
+}
+
+async function sendEmail(subject, html) {
+    log.info(`Sending email to ${notificationEmail}: ${subject}`);
+    await Actor.call('apify/send-mail', {
+        to: notificationEmail,
+        subject,
+        html,
+    });
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// --- Watcher ------------------------------------------------------------------
+const fixture = await resolveFixture();
+const fixtureId = fixture.fixture.id;
+const homeName = fixture.teams.home.name;
+const awayName = fixture.teams.away.name;
+log.info(`Watching fixture ${fixtureId}: ${homeName} vs ${awayName} (${fixture.league?.name ?? 'unknown league'}).`);
+
+// Restore state across migrations so restarts don't re-send goals we already emailed.
+const state = (await Actor.getValue(STATE_KEY)) ?? { seenGoals: [], kickoffNotified: false };
+const seenGoals = new Set(state.seenGoals);
+let kickoffNotified = state.kickoffNotified;
+
+const persistState = async () => {
+    await Actor.setValue(STATE_KEY, { seenGoals: [...seenGoals], kickoffNotified });
+};
+Actor.on('migrating', persistState);
+
+const deadline = Date.now() + maxRuntimeSecs * 1000;
+let finished = false;
+
+while (!finished && Date.now() < deadline) {
+    let statusShort = 'NS';
+    try {
+        const [current] = await apiFootball('/fixtures', { id: fixtureId });
+        statusShort = current?.fixture?.status?.short ?? statusShort;
+        const goalsHome = current?.goals?.home ?? 0;
+        const goalsAway = current?.goals?.away ?? 0;
+        const scoreLine = `${homeName} ${goalsHome} - ${goalsAway} ${awayName}`;
+        await Actor.setStatusMessage(`[${statusShort}] ${scoreLine}`);
+
+        // Kickoff email (once), when the match transitions into a live state.
+        if (notifyOnKickoffAndFullTime && !kickoffNotified && LIVE_STATUSES.has(statusShort)) {
+            kickoffNotified = true;
+            await sendEmail(
+                `⚽ Kickoff: ${homeName} vs ${awayName}`,
+                `<p>The match <b>${homeName} vs ${awayName}</b> has kicked off. You'll get an email for every goal.</p>`,
+            );
+            await persistState();
+        }
+
+        // Fetch and diff goal events.
+        const events = await apiFootball('/fixtures/events', { fixture: fixtureId });
+        for (const ev of events.filter(isGoal)) {
+            const key = goalKey(ev);
+            if (seenGoals.has(key)) continue;
+            seenGoals.add(key);
+
+            const minute = `${ev.time.elapsed}${ev.time.extra ? `+${ev.time.extra}` : ''}'`;
+            const scorer = ev.player?.name ?? 'Unknown';
+            const assist = ev.assist?.name ?? null;
+            const detail = ev.detail ?? 'Goal';
+            const team = ev.team?.name ?? '';
+
+            await Actor.pushData({
+                fixtureId,
+                minute,
+                team,
+                scorer,
+                assist,
+                detail,
+                score: scoreLine,
+                notifiedAt: new Date().toISOString(),
+            });
+
+            const detailSuffix = detail && detail !== 'Normal Goal' ? ` (${detail})` : '';
+            const assistLine = assist ? `<p>Assist: ${assist}</p>` : '';
+            await sendEmail(
+                `⚽ GOAL! ${scorer} (${team}) — ${minute}`,
+                `<h2>${team} score!</h2>` +
+                    `<p><b>${scorer}</b> ${minute}${detailSuffix}</p>` +
+                    assistLine +
+                    `<p>Current score: <b>${scoreLine}</b></p>`,
+            );
+            await persistState();
+        }
+
+        if (FINISHED_STATUSES.has(statusShort)) {
+            finished = true;
+            if (notifyOnKickoffAndFullTime) {
+                await sendEmail(
+                    `🏁 Full time: ${scoreLine}`,
+                    `<p>The match has finished.</p><p>Final score: <b>${scoreLine}</b></p>`,
+                );
+            }
+            log.info(`Match finished (${statusShort}). Final score: ${scoreLine}.`);
+        } else if (ABANDONED_STATUSES.has(statusShort)) {
+            finished = true;
+            log.warning(`Match will not continue (status ${statusShort}). Stopping watcher.`);
+            await Actor.setStatusMessage(`Match not played to completion (${statusShort}).`);
+        }
+    } catch (err) {
+        // Transient API/network hiccups shouldn't kill a multi-hour watch — log and retry next tick.
+        log.warning(`Poll failed, will retry: ${err.message}`);
+    }
+
+    if (!finished) await sleep(pollIntervalSecs * 1000);
+}
+
+await persistState();
+if (!finished) log.warning(`Reached maxRuntimeSecs (${maxRuntimeSecs}s) before the match finished — stopping.`);
+
+await Actor.exit();


### PR DESCRIPTION
Add a self-contained Apify Actor that watches a single live football
match (e.g. Belgium vs Spain) and emails the user whenever anyone scores.

- Live goal events from API-Football (RapidAPI): scorer, minute, assist,
  goal type; polls fixture status/score and events on an interval.
- Emails one message per goal via the apify/send-mail Actor (no SMTP
  credentials needed); optional kickoff and full-time emails.
- Resolves the fixture from an explicit fixtureId or by matching team
  names on a date; dedupes goals and persists watcher state across
  migrations so restarts don't re-notify.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MtPRNA5xXr7V7iPsonVFKb