### PR TITLE
test(python-playwright-camoufox): Set `no_viewport` for Camoufox test for compatibility with Playwright 1.61.0

### DIFF
--- a/python-playwright-camoufox/src/main.py
+++ b/python-playwright-camoufox/src/main.py
@@ -31,7 +31,7 @@ def print_image_info():
 async def run_test(headless=True):
     print(f"Testing Camoufox with {headless=}")
     async with AsyncCamoufox(headless=headless) as browser:
-        page = await browser.new_page()
+        page = await browser.new_page(no_viewport=True)
         await page.goto("http://www.example.com")
         title = await page.title()
         if title != "Example Domain":


### PR DESCRIPTION
Set `no_viewport` for Camoufox test for compatibility with Playwright 1.61.0. This is necessary because of https://github.com/daijro/camoufox/issues/653