### PR TITLE
feat(node): install Corepack and centralize package-manager caches

### DIFF
--- a/.github/workflows/release-node-playwright.yaml
+++ b/.github/workflows/release-node-playwright.yaml
@@ -228,6 +228,18 @@ jobs:
       - name: Test image
         run: docker run ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }}
 
+      - name: Test package manager configuration
+        run: |
+          docker run --rm ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }} sh -c '
+            set -ex
+            test "$(npm config get cache)" = "/pkg-cache/npm"
+            pnpm store path | grep -q "^/pkg-cache/pnpm/store"
+            test "$(pnpm config get node-linker)" = "hoisted"
+            corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"
+            ! npm config list 2>&1 | grep -qi "unknown"
+            yarn cache dir | grep -q "^/pkg-cache/yarn"
+          '
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4

--- a/.github/workflows/release-node-playwright.yaml
+++ b/.github/workflows/release-node-playwright.yaml
@@ -236,7 +236,7 @@ jobs:
             pnpm store path | grep -q "^/pkg-cache/pnpm/store"
             test "$(pnpm config get node-linker)" = "hoisted"
             corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"
-            ! npm config list 2>&1 | grep -qi "unknown"
+            if npm config list 2>&1 | grep -qi "unknown"; then exit 1; fi
             yarn cache dir | grep -q "^/pkg-cache/yarn"
           '
 

--- a/.github/workflows/release-node-puppeteer.yaml
+++ b/.github/workflows/release-node-puppeteer.yaml
@@ -217,7 +217,7 @@ jobs:
             pnpm store path | grep -q "^/pkg-cache/pnpm/store"
             test "$(pnpm config get node-linker)" = "hoisted"
             corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"
-            ! npm config list 2>&1 | grep -qi "unknown"
+            if npm config list 2>&1 | grep -qi "unknown"; then exit 1; fi
             yarn cache dir | grep -q "^/pkg-cache/yarn"
           '
 

--- a/.github/workflows/release-node-puppeteer.yaml
+++ b/.github/workflows/release-node-puppeteer.yaml
@@ -209,6 +209,18 @@ jobs:
       - name: Test image
         run: docker run ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }}
 
+      - name: Test package manager configuration
+        run: |
+          docker run --rm ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }} sh -c '
+            set -ex
+            test "$(npm config get cache)" = "/pkg-cache/npm"
+            pnpm store path | grep -q "^/pkg-cache/pnpm/store"
+            test "$(pnpm config get node-linker)" = "hoisted"
+            corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"
+            ! npm config list 2>&1 | grep -qi "unknown"
+            yarn cache dir | grep -q "^/pkg-cache/yarn"
+          '
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4

--- a/.github/workflows/release-node.yaml
+++ b/.github/workflows/release-node.yaml
@@ -209,7 +209,7 @@ jobs:
             pnpm store path | grep -q "^/pkg-cache/pnpm/store"
             test "$(pnpm config get node-linker)" = "hoisted"
             corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"
-            ! npm config list 2>&1 | grep -qi "unknown"
+            if npm config list 2>&1 | grep -qi "unknown"; then exit 1; fi
             yarn cache dir | grep -q "^/pkg-cache/yarn"
           '
 

--- a/.github/workflows/release-node.yaml
+++ b/.github/workflows/release-node.yaml
@@ -201,6 +201,18 @@ jobs:
       - name: Test image
         run: docker run ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }}
 
+      - name: Test package manager configuration
+        run: |
+          docker run --rm ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }} sh -c '
+            set -ex
+            test "$(npm config get cache)" = "/pkg-cache/npm"
+            pnpm store path | grep -q "^/pkg-cache/pnpm/store"
+            test "$(pnpm config get node-linker)" = "hoisted"
+            corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"
+            ! npm config list 2>&1 | grep -qi "unknown"
+            yarn cache dir | grep -q "^/pkg-cache/yarn"
+          '
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v4

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -66,6 +66,15 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into the global bin.
+    && npm install -g corepack@latest \
+    && corepack enable \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -89,6 +98,20 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -93,9 +93,14 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
     && apt clean -y && apt autoremove -y \
-    && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -67,8 +67,8 @@ RUN apt update \
     && npm config --global set update-notifier false \
     \
     # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
-    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
-    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    # the global bin. --force: the base images already ship yarn and/or corepack binaries, which
+    # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
     # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -66,6 +66,29 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
+    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
+    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    && npm install -g --force corepack@latest \
+    && corepack enable \
+    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
+    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
+    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
+    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
+    # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
+    # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
+    # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
+    # pin pnpm@10 via `packageManager` resolve to /pkg-cache too.
+    && mkdir -p /root/.config/pnpm /home/myuser/.config/pnpm \
+    && printf 'store-dir=/pkg-cache/pnpm/store\ncache-dir=/pkg-cache/pnpm/cache\nnode-linker=hoisted\n' > /root/.config/pnpm/rc \
+    && cp /root/.config/pnpm/rc /home/myuser/.config/pnpm/rc \
+    && chown -R myuser:myuser /home/myuser/.config \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -89,6 +112,24 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# COREPACK_HOME holds the package-manager versions corepack provisions on demand.
+# NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
+# from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
+    COREPACK_HOME=/pkg-cache/corepack
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -81,7 +81,13 @@ RUN apt update \
     && apt clean -y && apt autoremove -y \
     && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -109,9 +109,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -127,9 +127,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
     COREPACK_HOME=/pkg-cache/corepack
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -81,6 +81,15 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into the global bin.
+    && npm install -g corepack@latest \
+    && corepack enable \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -104,6 +113,20 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -108,9 +108,14 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
     && apt clean -y && apt autoremove -y \
-    && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -124,9 +124,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -96,7 +96,13 @@ RUN apt update \
     && apt clean -y && apt autoremove -y \
     && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -142,9 +142,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
     COREPACK_HOME=/pkg-cache/corepack
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -81,6 +81,29 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
+    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
+    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    && npm install -g --force corepack@latest \
+    && corepack enable \
+    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
+    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
+    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
+    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
+    # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
+    # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
+    # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
+    # pin pnpm@10 via `packageManager` resolve to /pkg-cache too.
+    && mkdir -p /root/.config/pnpm /home/myuser/.config/pnpm \
+    && printf 'store-dir=/pkg-cache/pnpm/store\ncache-dir=/pkg-cache/pnpm/cache\nnode-linker=hoisted\n' > /root/.config/pnpm/rc \
+    && cp /root/.config/pnpm/rc /home/myuser/.config/pnpm/rc \
+    && chown -R myuser:myuser /home/myuser/.config \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -104,6 +127,24 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# COREPACK_HOME holds the package-manager versions corepack provisions on demand.
+# NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
+# from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
+    COREPACK_HOME=/pkg-cache/corepack
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -82,8 +82,8 @@ RUN apt update \
     && npm config --global set update-notifier false \
     \
     # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
-    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
-    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    # the global bin. --force: the base images already ship yarn and/or corepack binaries, which
+    # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
     # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -71,6 +71,15 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into the global bin.
+    && npm install -g corepack@latest \
+    && corepack enable \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -94,6 +103,20 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -132,9 +132,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
     COREPACK_HOME=/pkg-cache/corepack
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -114,9 +114,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -71,6 +71,29 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
+    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
+    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    && npm install -g --force corepack@latest \
+    && corepack enable \
+    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
+    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
+    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
+    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
+    # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
+    # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
+    # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
+    # pin pnpm@10 via `packageManager` resolve to /pkg-cache too.
+    && mkdir -p /root/.config/pnpm /home/myuser/.config/pnpm \
+    && printf 'store-dir=/pkg-cache/pnpm/store\ncache-dir=/pkg-cache/pnpm/cache\nnode-linker=hoisted\n' > /root/.config/pnpm/rc \
+    && cp /root/.config/pnpm/rc /home/myuser/.config/pnpm/rc \
+    && chown -R myuser:myuser /home/myuser/.config \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -94,6 +117,24 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# COREPACK_HOME holds the package-manager versions corepack provisions on demand.
+# NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
+# from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
+    COREPACK_HOME=/pkg-cache/corepack
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -98,9 +98,14 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
     && apt clean -y && apt autoremove -y \
-    && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -86,7 +86,13 @@ RUN apt update \
     && apt clean -y && apt autoremove -y \
     && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -72,8 +72,8 @@ RUN apt update \
     && npm config --global set update-notifier false \
     \
     # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
-    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
-    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    # the global bin. --force: the base images already ship yarn and/or corepack binaries, which
+    # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
     # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -60,6 +60,15 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into the global bin.
+    && npm install -g corepack@latest \
+    && corepack enable \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -83,6 +92,20 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -121,9 +121,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
     COREPACK_HOME=/pkg-cache/corepack
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -61,8 +61,8 @@ RUN apt update \
     && npm config --global set update-notifier false \
     \
     # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
-    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
-    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    # the global bin. --force: the base images already ship yarn and/or corepack binaries, which
+    # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
     # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -60,6 +60,29 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
+    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
+    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    && npm install -g --force corepack@latest \
+    && corepack enable \
+    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
+    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
+    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
+    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
+    # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
+    # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
+    # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
+    # pin pnpm@10 via `packageManager` resolve to /pkg-cache too.
+    && mkdir -p /root/.config/pnpm /home/myuser/.config/pnpm \
+    && printf 'store-dir=/pkg-cache/pnpm/store\ncache-dir=/pkg-cache/pnpm/cache\nnode-linker=hoisted\n' > /root/.config/pnpm/rc \
+    && cp /root/.config/pnpm/rc /home/myuser/.config/pnpm/rc \
+    && chown -R myuser:myuser /home/myuser/.config \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -83,6 +106,24 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# COREPACK_HOME holds the package-manager versions corepack provisions on demand.
+# NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
+# from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
+    COREPACK_HOME=/pkg-cache/corepack
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -75,7 +75,13 @@ RUN apt update \
     && apt clean -y && apt autoremove -y \
     && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -87,9 +87,14 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
     && apt clean -y && apt autoremove -y \
-    && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -103,9 +103,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -83,6 +83,15 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into the global bin.
+    && npm install -g corepack@latest \
+    && corepack enable \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -106,6 +115,20 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -84,8 +84,8 @@ RUN apt update \
     && npm config --global set update-notifier false \
     \
     # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
-    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
-    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    # the global bin. --force: the base images already ship yarn and/or corepack binaries, which
+    # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
     # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -98,7 +98,13 @@ RUN apt update \
     && apt clean -y && apt autoremove -y \
     && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -110,9 +110,14 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
     && apt clean -y && apt autoremove -y \
-    && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -83,6 +83,29 @@ RUN apt update \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
     \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
+    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
+    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    && npm install -g --force corepack@latest \
+    && corepack enable \
+    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
+    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
+    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
+    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
+    # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
+    # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
+    # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
+    # pin pnpm@10 via `packageManager` resolve to /pkg-cache too.
+    && mkdir -p /root/.config/pnpm /home/myuser/.config/pnpm \
+    && printf 'store-dir=/pkg-cache/pnpm/store\ncache-dir=/pkg-cache/pnpm/cache\nnode-linker=hoisted\n' > /root/.config/pnpm/rc \
+    && cp /root/.config/pnpm/rc /home/myuser/.config/pnpm/rc \
+    && chown -R myuser:myuser /home/myuser/.config \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
+    \
     # Cleanup time
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -106,6 +129,24 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# COREPACK_HOME holds the package-manager versions corepack provisions on demand.
+# NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
+# from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
+    COREPACK_HOME=/pkg-cache/corepack
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -144,9 +144,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
     COREPACK_HOME=/pkg-cache/corepack
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -126,9 +126,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -90,6 +90,15 @@ RUN apt update \
     \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
+    \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into the global bin.
+    && npm install -g corepack@latest \
+    && corepack enable \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
     # Cleanup
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -113,6 +122,20 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -151,9 +151,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
     COREPACK_HOME=/pkg-cache/corepack
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -92,8 +92,8 @@ RUN apt update \
     && npm config --global set update-notifier false \
     \
     # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
-    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
-    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    # the global bin. --force: the base images already ship yarn and/or corepack binaries, which
+    # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
     # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -105,7 +105,13 @@ RUN apt update \
     && apt clean -y && apt autoremove -y \
     && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -90,6 +90,29 @@ RUN apt update \
     \
     # Globally disable the update-notifier.
     && npm config --global set update-notifier false \
+    \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
+    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
+    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    && npm install -g --force corepack@latest \
+    && corepack enable \
+    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
+    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
+    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
+    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
+    # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
+    # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
+    # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
+    # pin pnpm@10 via `packageManager` resolve to /pkg-cache too.
+    && mkdir -p /root/.config/pnpm /home/myuser/.config/pnpm \
+    && printf 'store-dir=/pkg-cache/pnpm/store\ncache-dir=/pkg-cache/pnpm/cache\nnode-linker=hoisted\n' > /root/.config/pnpm/rc \
+    && cp /root/.config/pnpm/rc /home/myuser/.config/pnpm/rc \
+    && chown -R myuser:myuser /home/myuser/.config \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache \
     # Cleanup
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
@@ -113,6 +136,24 @@ ENV NODE_ENV=production
 # However they did not think about all the sites there with large headers,
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# COREPACK_HOME holds the package-manager versions corepack provisions on demand.
+# NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
+# from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
+    COREPACK_HOME=/pkg-cache/corepack
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -117,9 +117,14 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /src/*.deb \
     && apt clean -y && apt autoremove -y \
-    && rm -rf /root/.npm \
     # This is needed to remove an annoying error message when running headful.
-    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+    && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -133,9 +133,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -14,12 +14,35 @@ RUN npm config --global set update-notifier false \
     && chown -R myuser:myuser /home/myuser \
     && mkdir -p /usr/src/app \
     && chown -R myuser:myuser /usr/src/app \
-    && ln -s /usr/src/app /home/myuser
+    && ln -s /usr/src/app /home/myuser \
+    \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into the global bin.
+    && npm install -g corepack@latest \
+    && corepack enable \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache
 
 WORKDIR /usr/src/app
 
 # Copy source code
 COPY --chown=myuser:myuser package.json main.js .
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -37,7 +37,13 @@ RUN npm config --global set update-notifier false \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
     && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
-    && chmod -R 777 /pkg-cache
+    && chmod -R 777 /pkg-cache \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 WORKDIR /usr/src/app
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -23,7 +23,13 @@ RUN npm config --global set update-notifier false \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
     && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
-    && chmod -R 777 /pkg-cache
+    && chmod -R 777 /pkg-cache \
+    \
+    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
+    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
+    && rm -rf /root/.npm /home/myuser/.npm \
+    && ln -s /pkg-cache/npm /root/.npm \
+    && ln -s /pkg-cache/npm /home/myuser/.npm
 
 WORKDIR /usr/src/app
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -40,9 +40,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -14,12 +14,53 @@ RUN npm config --global set update-notifier false \
     && chown -R myuser:myuser /home/myuser \
     && mkdir -p /usr/src/app \
     && chown -R myuser:myuser /usr/src/app \
-    && ln -s /usr/src/app /home/myuser
+    && ln -s /usr/src/app /home/myuser \
+    \
+    # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
+    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
+    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    && npm install -g --force corepack@latest \
+    && corepack enable \
+    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
+    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
+    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
+    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
+    # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
+    # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
+    # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
+    # pin pnpm@10 via `packageManager` resolve to /pkg-cache too.
+    && mkdir -p /root/.config/pnpm /home/myuser/.config/pnpm \
+    && printf 'store-dir=/pkg-cache/pnpm/store\ncache-dir=/pkg-cache/pnpm/cache\nnode-linker=hoisted\n' > /root/.config/pnpm/rc \
+    && cp /root/.config/pnpm/rc /home/myuser/.config/pnpm/rc \
+    && chown -R myuser:myuser /home/myuser/.config \
+    \
+    # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
+    # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
+    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && chmod -R 777 /pkg-cache
 
 WORKDIR /usr/src/app
 
 # Copy source code
 COPY --chown=myuser:myuser package.json main.js .
+
+# Send every package-manager cache to a single, dedicated location instead of $HOME.
+# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
+# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
+# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# COREPACK_HOME holds the package-manager versions corepack provisions on demand.
+# NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
+# from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
+ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
+    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+    YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
+    PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
+    PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
+    COREPACK_HOME=/pkg-cache/corepack
+
+# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
+# default symlinked layout, so installed dependencies are plain copies with no symlinks.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -58,9 +58,11 @@ ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \
     COREPACK_HOME=/pkg-cache/corepack
 
-# Make pnpm use a flat, npm-style node_modules (the `hoisted` linker) instead of its
-# default symlinked layout, so installed dependencies are plain copies with no symlinks.
-ENV PNPM_CONFIG_NODE_LINKER=hoisted
+# Make pnpm and yarn use a flat, npm-style node_modules instead of their non-node_modules
+# defaults (pnpm's symlinked store, yarn Berry's Plug'n'Play), so installed dependencies are
+# plain copies that any tooling can resolve without symlinks or a PnP loader.
+ENV PNPM_CONFIG_NODE_LINKER=hoisted \
+    YARN_NODE_LINKER=node-modules
 
 # Install default dependencies, print versions of everything
 RUN npm --quiet set progress=false \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -17,8 +17,8 @@ RUN npm config --global set update-notifier false \
     && ln -s /usr/src/app /home/myuser \
     \
     # Install the latest Corepack so Actors can opt into yarn or pnpm; `enable` drops the shims into
-    # the global bin. --force: some base images (mcr playwright) already ship a yarn binary, which
-    # npm otherwise refuses to overwrite with corepack's yarn shim.
+    # the global bin. --force: the base images already ship yarn and/or corepack binaries, which
+    # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
     # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the


### PR DESCRIPTION
## What

All 7 node base images (`node`, `node-playwright[-chrome/-firefox/-webkit/-camoufox]`, `node-puppeteer-chrome`) now:

- **Install Corepack** (`npm install -g --force corepack@latest && corepack enable`) so Actors can use yarn or pnpm out of the box. `--force` because some base images (mcr playwright) already ship a yarn binary that npm would otherwise refuse to overwrite. pnpm ≥ 11 is provisioned at build time (`corepack install -g pnpm@latest`) so the default pnpm is one that honors the env config below, with no download at first use.
- **Redirect every package-manager cache to a stable location** under `/pkg-cache`:
  - `NPM_CONFIG_CACHE=/pkg-cache/npm`
  - `YARN_CACHE_FOLDER` / `YARN_GLOBAL_FOLDER=/pkg-cache/yarn`
  - `PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store`, `PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache` (pnpm ≥ 11)
  - pnpm 10 ignores `PNPM_CONFIG_*`, so the same settings are mirrored into pnpm's own global rc files (`/root/.config/pnpm/rc`, `/home/myuser/.config/pnpm/rc`) — the only mechanism pnpm 10 reads that npm ≥ 11 doesn't warn about
  - `COREPACK_HOME=/pkg-cache/corepack`, so package managers corepack provisions on demand land in the wipeable tree too

  The tree is pre-created and world-writable (`777`), so whatever user the Actor runs as can populate it — and `rm -rf /pkg-cache` at the end of a build to reclaim space, since it only ever holds throwaway cache data.
- **Symlink the default npm cache dirs** (`/root/.npm` and `/home/myuser/.npm`) to `/pkg-cache/npm`, so tooling that bypasses `NPM_CONFIG_CACHE` still hits the shared cache, and existing templates that run `rm -r ~/.npm` after install keep working.
- **Force node_modules-style installs** for the alternative package managers: `PNPM_CONFIG_NODE_LINKER=hoisted` (no symlinked store layout; via the rc files for pnpm 10) and `YARN_NODE_LINKER=node-modules` (yarn Berry would otherwise default to Plug'n'Play).
- **Verify all of it in CI**: the image test steps now assert inside every built image that npm/pnpm (11 and 10)/yarn resolve their caches to `/pkg-cache`, pnpm uses the hoisted linker, and npm emits no "Unknown config" warnings.

## Why

A single, predictable cache location is a prerequisite for dependency-caching strategies (pre-baked caches, BuildKit `--mount=type=cache` on `/pkg-cache`, tmpfs mounts), and Corepack makes yarn/pnpm first-class without users hacking it into their Dockerfiles.

## Caveats

- The pnpm 10 rc files are per-user (`/root`, `/home/myuser`). An Actor running as some other user with `packageManager: pnpm@10.x` still bypasses `/pkg-cache` (its store lands in that user's `$HOME`); pnpm ≥ 11 covers arbitrary users via the env vars. Given the images only define these two users, this is accepted rather than worked around.
- Wiping `/pkg-cache` also removes the corepack-provisioned package managers (`COREPACK_HOME`); corepack re-downloads on next use.

## Verification

Built `apify/actor-node:24` locally from this branch and checked inside the image:

- `/root/.npm` and `/home/myuser/.npm` → `/pkg-cache/npm`; `npm config get cache` → `/pkg-cache/npm`
- default `pnpm --version` → 11.22.0 (provisioned, works offline as `myuser`); `pnpm store path` → `/pkg-cache/pnpm/store/v11`; `node-linker` → `hoisted`
- `corepack pnpm@10.33.4 store path` (root and `myuser`) → `/pkg-cache/pnpm/store/v10`; `node-linker` → `hoisted`
- yarn 1: `yarn cache dir` → `/pkg-cache/yarn/v6`; yarn Berry resolves `nodeLinker=node-modules` and `cacheFolder=/pkg-cache/yarn/cache`
- `npm config list` emits no "Unknown config" warnings; `rm -r ~/.npm` as `myuser` succeeds (template compatibility)