### PR TITLE
fix: restore default npm cache and stop preinstalling pnpm

### DIFF
--- a/.github/workflows/release-node-playwright.yaml
+++ b/.github/workflows/release-node-playwright.yaml
@@ -248,7 +248,14 @@ jobs:
         run: |
           docker run --rm ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }} sh -c '
             set -ex
-            test "$(npm config get cache)" = "/pkg-cache/npm"
+            test "$(npm config get cache)" = "$HOME/.npm"
+            test ! -L "$HOME/.npm"
+            test ! -e /pkg-cache/npm
+            npm cache add is-number@7.0.0
+            test -d "$HOME/.npm/_cacache"
+            rm -rf "$HOME/.npm"
+            test ! -e "$HOME/.npm"
+            test -z "$(ls -A "$COREPACK_HOME")"
             pnpm store path | grep -q "^/pkg-cache/pnpm/store"
             test "$(pnpm config get node-linker)" = "hoisted"
             corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"

--- a/.github/workflows/release-node-puppeteer.yaml
+++ b/.github/workflows/release-node-puppeteer.yaml
@@ -229,7 +229,14 @@ jobs:
         run: |
           docker run --rm ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }} sh -c '
             set -ex
-            test "$(npm config get cache)" = "/pkg-cache/npm"
+            test "$(npm config get cache)" = "$HOME/.npm"
+            test ! -L "$HOME/.npm"
+            test ! -e /pkg-cache/npm
+            npm cache add is-number@7.0.0
+            test -d "$HOME/.npm/_cacache"
+            rm -rf "$HOME/.npm"
+            test ! -e "$HOME/.npm"
+            test -z "$(ls -A "$COREPACK_HOME")"
             pnpm store path | grep -q "^/pkg-cache/pnpm/store"
             test "$(pnpm config get node-linker)" = "hoisted"
             corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"

--- a/.github/workflows/release-node.yaml
+++ b/.github/workflows/release-node.yaml
@@ -221,7 +221,14 @@ jobs:
         run: |
           docker run --rm ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }} sh -c '
             set -ex
-            test "$(npm config get cache)" = "/pkg-cache/npm"
+            test "$(npm config get cache)" = "$HOME/.npm"
+            test ! -L "$HOME/.npm"
+            test ! -e /pkg-cache/npm
+            npm cache add is-number@7.0.0
+            test -d "$HOME/.npm/_cacache"
+            rm -rf "$HOME/.npm"
+            test ! -e "$HOME/.npm"
+            test -z "$(ls -A "$COREPACK_HOME")"
             pnpm store path | grep -q "^/pkg-cache/pnpm/store"
             test "$(pnpm config get node-linker)" = "hoisted"
             corepack pnpm@10 store path | grep -q "^/pkg-cache/pnpm/store"

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -71,10 +71,6 @@ RUN apt update \
     # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
-    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
-    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
-    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
-    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
     # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
     # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
     # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
@@ -86,7 +82,7 @@ RUN apt update \
     \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
-    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && mkdir -p /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache /pkg-cache/corepack \
     && chmod -R 777 /pkg-cache \
     \
     # Cleanup time
@@ -96,11 +92,8 @@ RUN apt update \
     # This is needed to remove an annoying error message when running headful.
     && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
     \
-    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
-    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
-    && rm -rf /root/.npm /home/myuser/.npm \
-    && ln -s /pkg-cache/npm /root/.npm \
-    && ln -s /pkg-cache/npm /home/myuser/.npm
+    # Clear npm caches populated during setup.
+    && rm -rf /root/.npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser
@@ -118,15 +111,12 @@ ENV NODE_ENV=production
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
-# Send every package-manager cache to a single, dedicated location instead of $HOME.
-# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
-# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
-# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# Keep yarn and pnpm caches under /pkg-cache so they can be removed after installation.
+# npm uses its default ~/.npm directory so existing cache cleanup commands still work.
 # COREPACK_HOME holds the package-manager versions corepack provisions on demand.
 # NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
 # from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
-ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
-    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+ENV YARN_CACHE_FOLDER=/pkg-cache/yarn \
     YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \

--- a/node-playwright-chrome/Dockerfile
+++ b/node-playwright-chrome/Dockerfile
@@ -86,10 +86,6 @@ RUN apt update \
     # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
-    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
-    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
-    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
-    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
     # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
     # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
     # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
@@ -101,7 +97,7 @@ RUN apt update \
     \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
-    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && mkdir -p /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache /pkg-cache/corepack \
     && chmod -R 777 /pkg-cache \
     \
     # Cleanup time
@@ -111,11 +107,8 @@ RUN apt update \
     # This is needed to remove an annoying error message when running headful.
     && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
     \
-    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
-    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
-    && rm -rf /root/.npm /home/myuser/.npm \
-    && ln -s /pkg-cache/npm /root/.npm \
-    && ln -s /pkg-cache/npm /home/myuser/.npm
+    # Clear npm caches populated during setup.
+    && rm -rf /root/.npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser
@@ -133,15 +126,12 @@ ENV NODE_ENV=production
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
-# Send every package-manager cache to a single, dedicated location instead of $HOME.
-# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
-# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
-# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# Keep yarn and pnpm caches under /pkg-cache so they can be removed after installation.
+# npm uses its default ~/.npm directory so existing cache cleanup commands still work.
 # COREPACK_HOME holds the package-manager versions corepack provisions on demand.
 # NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
 # from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
-ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
-    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+ENV YARN_CACHE_FOLDER=/pkg-cache/yarn \
     YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \

--- a/node-playwright-firefox/Dockerfile
+++ b/node-playwright-firefox/Dockerfile
@@ -76,10 +76,6 @@ RUN apt update \
     # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
-    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
-    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
-    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
-    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
     # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
     # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
     # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
@@ -91,7 +87,7 @@ RUN apt update \
     \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
-    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && mkdir -p /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache /pkg-cache/corepack \
     && chmod -R 777 /pkg-cache \
     \
     # Cleanup time
@@ -101,11 +97,8 @@ RUN apt update \
     # This is needed to remove an annoying error message when running headful.
     && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
     \
-    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
-    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
-    && rm -rf /root/.npm /home/myuser/.npm \
-    && ln -s /pkg-cache/npm /root/.npm \
-    && ln -s /pkg-cache/npm /home/myuser/.npm
+    # Clear npm caches populated during setup.
+    && rm -rf /root/.npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser
@@ -123,15 +116,12 @@ ENV NODE_ENV=production
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
-# Send every package-manager cache to a single, dedicated location instead of $HOME.
-# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
-# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
-# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# Keep yarn and pnpm caches under /pkg-cache so they can be removed after installation.
+# npm uses its default ~/.npm directory so existing cache cleanup commands still work.
 # COREPACK_HOME holds the package-manager versions corepack provisions on demand.
 # NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
 # from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
-ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
-    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+ENV YARN_CACHE_FOLDER=/pkg-cache/yarn \
     YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \

--- a/node-playwright-webkit/Dockerfile
+++ b/node-playwright-webkit/Dockerfile
@@ -65,10 +65,6 @@ RUN apt update \
     # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
-    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
-    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
-    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
-    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
     # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
     # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
     # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
@@ -80,7 +76,7 @@ RUN apt update \
     \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
-    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && mkdir -p /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache /pkg-cache/corepack \
     && chmod -R 777 /pkg-cache \
     \
     # Cleanup time
@@ -90,11 +86,8 @@ RUN apt update \
     # This is needed to remove an annoying error message when running headful.
     && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
     \
-    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
-    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
-    && rm -rf /root/.npm /home/myuser/.npm \
-    && ln -s /pkg-cache/npm /root/.npm \
-    && ln -s /pkg-cache/npm /home/myuser/.npm
+    # Clear npm caches populated during setup.
+    && rm -rf /root/.npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser
@@ -112,15 +105,12 @@ ENV NODE_ENV=production
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
-# Send every package-manager cache to a single, dedicated location instead of $HOME.
-# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
-# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
-# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# Keep yarn and pnpm caches under /pkg-cache so they can be removed after installation.
+# npm uses its default ~/.npm directory so existing cache cleanup commands still work.
 # COREPACK_HOME holds the package-manager versions corepack provisions on demand.
 # NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
 # from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
-ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
-    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+ENV YARN_CACHE_FOLDER=/pkg-cache/yarn \
     YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \

--- a/node-playwright/Dockerfile
+++ b/node-playwright/Dockerfile
@@ -88,10 +88,6 @@ RUN apt update \
     # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
-    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
-    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
-    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
-    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
     # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
     # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
     # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
@@ -103,7 +99,7 @@ RUN apt update \
     \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
-    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && mkdir -p /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache /pkg-cache/corepack \
     && chmod -R 777 /pkg-cache \
     \
     # Cleanup time
@@ -113,11 +109,8 @@ RUN apt update \
     # This is needed to remove an annoying error message when running headful.
     && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
     \
-    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
-    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
-    && rm -rf /root/.npm /home/myuser/.npm \
-    && ln -s /pkg-cache/npm /root/.npm \
-    && ln -s /pkg-cache/npm /home/myuser/.npm
+    # Clear npm caches populated during setup.
+    && rm -rf /root/.npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser
@@ -135,15 +128,12 @@ ENV NODE_ENV=production
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
-# Send every package-manager cache to a single, dedicated location instead of $HOME.
-# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
-# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
-# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# Keep yarn and pnpm caches under /pkg-cache so they can be removed after installation.
+# npm uses its default ~/.npm directory so existing cache cleanup commands still work.
 # COREPACK_HOME holds the package-manager versions corepack provisions on demand.
 # NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
 # from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
-ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
-    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+ENV YARN_CACHE_FOLDER=/pkg-cache/yarn \
     YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \

--- a/node-puppeteer-chrome/Dockerfile
+++ b/node-puppeteer-chrome/Dockerfile
@@ -96,10 +96,6 @@ RUN apt update \
     # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
-    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
-    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
-    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
-    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
     # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
     # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
     # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
@@ -111,7 +107,7 @@ RUN apt update \
     \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
-    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && mkdir -p /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache /pkg-cache/corepack \
     && chmod -R 777 /pkg-cache \
     # Cleanup
     && rm -rf /var/lib/apt/lists/* \
@@ -120,11 +116,8 @@ RUN apt update \
     # This is needed to remove an annoying error message when running headful.
     && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix \
     \
-    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
-    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
-    && rm -rf /root/.npm /home/myuser/.npm \
-    && ln -s /pkg-cache/npm /root/.npm \
-    && ln -s /pkg-cache/npm /home/myuser/.npm
+    # Clear npm caches populated during setup.
+    && rm -rf /root/.npm /home/myuser/.npm
 
 # Run everything after as non-privileged user.
 USER myuser
@@ -142,15 +135,12 @@ ENV NODE_ENV=production
 # so we put back the old limit of 80kb, which seems to work just fine.
 ENV NODE_OPTIONS="--max_old_space_size=30000 --max-http-header-size=80000"
 
-# Send every package-manager cache to a single, dedicated location instead of $HOME.
-# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
-# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
-# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# Keep yarn and pnpm caches under /pkg-cache so they can be removed after installation.
+# npm uses its default ~/.npm directory so existing cache cleanup commands still work.
 # COREPACK_HOME holds the package-manager versions corepack provisions on demand.
 # NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
 # from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
-ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
-    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+ENV YARN_CACHE_FOLDER=/pkg-cache/yarn \
     YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -21,10 +21,6 @@ RUN npm config --global set update-notifier false \
     # npm otherwise refuses to overwrite with corepack's shims.
     && npm install -g --force corepack@latest \
     && corepack enable \
-    # Make pnpm >= 11 the version corepack provisions by default: pnpm 10 ignores the
-    # PNPM_CONFIG_* env vars set below, so its store and cache would land in $HOME instead
-    # of /pkg-cache. COREPACK_HOME is passed inline because its ENV is declared further down.
-    && COREPACK_HOME=/pkg-cache/corepack corepack install -g pnpm@latest \
     # pnpm 10 ignores the PNPM_CONFIG_* env vars set further down (they are pnpm >= 11 only),
     # and npm >= 11 warns on the equivalent npmrc keys / NPM_CONFIG_* vars, so mirror the
     # settings into pnpm's own global rc files, which only pnpm reads. This makes Actors that
@@ -36,14 +32,11 @@ RUN npm config --global set update-notifier false \
     \
     # Pre-create the shared package-manager cache dirs (see the *_CACHE_*/*_STORE_DIR env vars), world-writable so any
     # user can populate them and `rm -rf` them at the end to reclaim space, regardless of which user the Actor runs as.
-    && mkdir -p /pkg-cache/npm /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache \
+    && mkdir -p /pkg-cache/yarn /pkg-cache/pnpm/store /pkg-cache/pnpm/cache /pkg-cache/corepack \
     && chmod -R 777 /pkg-cache \
     \
-    # Point the default per-user npm cache dirs (~/.npm) at the shared cache, so tooling
-    # that bypasses NPM_CONFIG_CACHE - and templates that `rm -r ~/.npm` - keep working.
-    && rm -rf /root/.npm /home/myuser/.npm \
-    && ln -s /pkg-cache/npm /root/.npm \
-    && ln -s /pkg-cache/npm /home/myuser/.npm
+    # Clear npm caches populated during setup.
+    && rm -rf /root/.npm /home/myuser/.npm
 
 WORKDIR /usr/src/app
 
@@ -55,15 +48,12 @@ COPY --chown=myuser:myuser package.json package.slim.json main.js .
 ARG SLIM=0
 RUN if [ "$SLIM" = "1" ]; then mv package.slim.json package.json; else rm package.slim.json; fi
 
-# Send every package-manager cache to a single, dedicated location instead of $HOME.
-# npm, yarn, and pnpm have no real "disable the cache" switch (unlike pip), so isolating
-# their caches under /pkg-cache is the practical equivalent: the tree holds only throwaway
-# cache data and can be wiped or mounted as tmpfs without touching installed dependencies.
+# Keep yarn and pnpm caches under /pkg-cache so they can be removed after installation.
+# npm uses its default ~/.npm directory so existing cache cleanup commands still work.
 # COREPACK_HOME holds the package-manager versions corepack provisions on demand.
 # NOTE: only pnpm >= 11 reads the PNPM_CONFIG_* vars; pnpm 10 picks up the same settings
 # from the global pnpm rc files written to /root/.config/pnpm and /home/myuser/.config/pnpm.
-ENV NPM_CONFIG_CACHE=/pkg-cache/npm \
-    YARN_CACHE_FOLDER=/pkg-cache/yarn \
+ENV YARN_CACHE_FOLDER=/pkg-cache/yarn \
     YARN_GLOBAL_FOLDER=/pkg-cache/yarn \
     PNPM_CONFIG_STORE_DIR=/pkg-cache/pnpm/store \
     PNPM_CONFIG_CACHE_DIR=/pkg-cache/pnpm/cache \


### PR DESCRIPTION
Restore npm's default per-user `~/.npm` cache across the seven Node images, including `/root/.npm` when running as root. Remove the cache override and symlinks so `rm -rf ~/.npm` removes the cached data.

Remove the pnpm preinstall. Keep Corepack enabled and its cache directory writable for on-demand package-manager downloads.

Validation: built the Node 24 Alpine slim image and verified cache population and deletion as root and myuser, an empty Corepack cache, and non-root write access to it. Shell syntax checks passed for all seven Dockerfiles. Full browser image builds were not run locally.

[🤖] Codex using GPT-6
