### PR TITLE
fix: authenticate camoufox fetch with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-node-playwright.yaml
+++ b/.github/workflows/release-node-playwright.yaml
@@ -240,6 +240,8 @@ jobs:
           tags: ${{ fromJson(steps.prepare-tags.outputs.result).allTags }}
           cache-from: type=gha,scope=${{ matrix.image-name }}-${{ matrix.node-version }}-${{ matrix.playwright-version }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image-name }}-${{ matrix.node-version }}-${{ matrix.playwright-version }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Test image
         run: docker run ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }}
@@ -281,6 +283,8 @@ jobs:
             type=gha,scope=${{ matrix.image-name }}-${{ matrix.node-version }}-${{ matrix.playwright-version }}-slim
             type=gha,scope=${{ matrix.image-name }}-${{ matrix.node-version }}-${{ matrix.playwright-version }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image-name }}-${{ matrix.node-version }}-${{ matrix.playwright-version }}-slim
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Test slim image
         run: docker run ${{ fromJson(steps.prepare-slim-tags.outputs.result).firstImageName }}
@@ -351,6 +355,8 @@ jobs:
           tags: ${{ fromJson(steps.prepare-tags.outputs.result).allTags }}
           outputs: type=image,oci-mediatypes=true
           cache-from: type=gha,scope=${{ matrix.image-name }}-${{ matrix.node-version }}-${{ matrix.playwright-version }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push slim OCI image
         if: github.event_name != 'pull_request'
@@ -370,6 +376,8 @@ jobs:
           cache-from: |
             type=gha,scope=${{ matrix.image-name }}-${{ matrix.node-version }}-${{ matrix.playwright-version }}-slim
             type=gha,scope=${{ matrix.image-name }}-${{ matrix.node-version }}-${{ matrix.playwright-version }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
 
   # Aggregate the per-image size reports uploaded by the build matrix and post/update
   # a single sticky PR comment comparing current vs new image sizes.

--- a/.github/workflows/release-python-playwright.yaml
+++ b/.github/workflows/release-python-playwright.yaml
@@ -183,6 +183,8 @@ jobs:
           tags: ${{ fromJson(steps.prepare-tags.outputs.result).allTags }}
           cache-from: type=gha,scope=${{ matrix.image-name }}-${{ matrix.python-version }}-${{ matrix.playwright-version }}-${{ matrix.camoufox-version }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image-name }}-${{ matrix.python-version }}-${{ matrix.playwright-version }}-${{ matrix.camoufox-version }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Test image
         run: docker run ${{ fromJson(steps.prepare-tags.outputs.result).firstImageName }}
@@ -245,6 +247,8 @@ jobs:
           tags: ${{ fromJson(steps.prepare-tags.outputs.result).allTags }}
           outputs: type=image,oci-mediatypes=true
           cache-from: type=gha,scope=${{ matrix.image-name }}-${{ matrix.python-version }}-${{ matrix.playwright-version }}-${{ matrix.camoufox-version }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
 
   # Aggregate the per-image size reports uploaded by the build matrix and post/update
   # a single sticky PR comment comparing current vs new image sizes.

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -135,10 +135,17 @@ ARG SLIM=0
 RUN if [ "$SLIM" = "1" ]; then mv package.slim.json package.json; else rm package.slim.json; fi
 
 # Install default dependencies, print versions of everything
-RUN npm --quiet set progress=false \
+#
+# `camoufox-js fetch` reads api.github.com, where the whole matrix shares one 60/hour budget.
+# GITHUB_TOKEN lifts it to 1000/hour; a secret, not a build arg, keeps it out of the layers.
+# mode=0444 because this stage runs as myuser and secrets default to root-owned 0400.
+# Without it the build stays unauthenticated and still works.
+RUN --mount=type=secret,id=github_token,mode=0444 \
+    npm --quiet set progress=false \
     \
     # Install Camoufox browser
-    && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx camoufox-js fetch \
+    && GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx camoufox-js fetch \
     # Overrides the dynamic library used by Firefox to determine trusted root certificates with p11-kit-trust.so, which loads the system certificates.
     && rm -f /home/myuser/.cache/camoufox/libnssckbi.so \
     && ln -s $(ls -d /usr/lib/*-linux-gnu)/pkcs11/p11-kit-trust.so /home/myuser/.cache/camoufox/libnssckbi.so \

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -136,16 +136,17 @@ RUN if [ "$SLIM" = "1" ]; then mv package.slim.json package.json; else rm packag
 
 # Install default dependencies, print versions of everything
 #
-# `camoufox-js fetch` reads api.github.com, where the whole matrix shares one 60/hour budget.
-# GITHUB_TOKEN lifts it to 1000/hour; a secret, not a build arg, keeps it out of the layers.
-# mode=0444 because this stage runs as myuser and secrets default to root-owned 0400.
-# Without it the build stays unauthenticated and still works.
+# GITHUB_TOKEN raises the api.github.com rate limit for `camoufox-js fetch`. A secret, not a build
+# arg, keeps it out of the layers; mode=0444 because this stage runs as myuser. Optional.
 RUN --mount=type=secret,id=github_token,mode=0444 \
     npm --quiet set progress=false \
     \
     # Install Camoufox browser
-    && GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
-    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx camoufox-js fetch \
+    && if [ -r /run/secrets/github_token ]; then \
+           GITHUB_TOKEN="$(cat /run/secrets/github_token)"; \
+           export GITHUB_TOKEN; \
+       fi \
+    && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx camoufox-js fetch \
     # Overrides the dynamic library used by Firefox to determine trusted root certificates with p11-kit-trust.so, which loads the system certificates.
     && rm -f /home/myuser/.cache/camoufox/libnssckbi.so \
     && ln -s $(ls -d /usr/lib/*-linux-gnu)/pkcs11/p11-kit-trust.so /home/myuser/.cache/camoufox/libnssckbi.so \

--- a/python-playwright-camoufox/Dockerfile
+++ b/python-playwright-camoufox/Dockerfile
@@ -103,14 +103,23 @@ ENV PATH="/root/.local/bin:/home/myuser/.local/bin:$PATH"
 # - Preinstalls the latest versions of setuptools and wheel to improve package installation speed
 # - Installs the specified version of Playwright and Camoufox
 # - Fetches the Camoufox browser
-RUN python -m pip install --upgrade \
+#
+# `camoufox fetch` reads api.github.com, where the whole matrix shares one 60/hour budget.
+# GITHUB_TOKEN lifts it to 1000/hour; a secret, not a build arg, keeps it out of the layers.
+# Without it the build stays unauthenticated and still works.
+RUN --mount=type=secret,id=github_token \
+    python -m pip install --upgrade \
     pip \
     setuptools \
     wheel \
     playwright~=${PLAYWRIGHT_VERSION} \
     camoufox[geoip]~=${CAMOUFOX_VERSION} \
     # Fetch the Camoufox browser
-    && python -m camoufox fetch \
+    && GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
+    python -m camoufox fetch \
+    # `camoufox fetch` swallows sync errors and exits 0, so check what the runtime checks
+    # rather than ship an image that only fails at launch.
+    && python -c "from camoufox.pkgman import installed_verstr; print('Camoufox installed:', installed_verstr())" \
     # Overrides the dynamic library used by Firefox to determine trusted root certificates with p11-kit-trust.so, which loads the system certificates.
     && rm -f /root/.cache/camoufox/libnssckbi.so \
     && ln -s /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so /root/.cache/camoufox/libnssckbi.so

--- a/python-playwright-camoufox/Dockerfile
+++ b/python-playwright-camoufox/Dockerfile
@@ -104,9 +104,8 @@ ENV PATH="/root/.local/bin:/home/myuser/.local/bin:$PATH"
 # - Installs the specified version of Playwright and Camoufox
 # - Fetches the Camoufox browser
 #
-# `camoufox fetch` reads api.github.com, where the whole matrix shares one 60/hour budget.
-# GITHUB_TOKEN lifts it to 1000/hour; a secret, not a build arg, keeps it out of the layers.
-# Without it the build stays unauthenticated and still works.
+# GITHUB_TOKEN raises the api.github.com rate limit for `camoufox fetch`. A secret, not a build
+# arg, keeps it out of the layers. Optional.
 RUN --mount=type=secret,id=github_token \
     python -m pip install --upgrade \
     pip \
@@ -115,8 +114,11 @@ RUN --mount=type=secret,id=github_token \
     playwright~=${PLAYWRIGHT_VERSION} \
     camoufox[geoip]~=${CAMOUFOX_VERSION} \
     # Fetch the Camoufox browser
-    && GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" \
-    python -m camoufox fetch \
+    && if [ -r /run/secrets/github_token ]; then \
+           GITHUB_TOKEN="$(cat /run/secrets/github_token)"; \
+           export GITHUB_TOKEN; \
+       fi \
+    && python -m camoufox fetch \
     # `camoufox fetch` swallows sync errors and exits 0, so check what the runtime checks
     # rather than ship an image that only fails at launch.
     && python -c "from camoufox.pkgman import installed_verstr; print('Camoufox installed:', installed_verstr())" \


### PR DESCRIPTION
> [!NOTE]
> I was testing my skill for flake job detection, I found this one and fixed it with `/fix-flaky-test`. Seems legit, feel free to take a look, cancel or whatever. cc @vladfrangu

----
## Problem

`camoufox fetch` lists releases from `api.github.com`. Unauthenticated, every leg of the image matrix shares one runner IP's **60 requests/hour** budget, so a leg occasionally loses the race and gets a 403:

```
Official... Error: 403 Client Error: rate limit exceeded for url:
https://api.github.com/repos/camoufox/camoufox/releases
Synced 0 versions from 0 repos.
Version 'official' not found in cache. Run 'camoufox sync'.
```

Seen in [run 34317591187](https://github.com/apify/apify-actor-docker/actions/runs/34317591187) — `py 3.14 / pw 1.60.0` red while **24 of the 25** camoufox legs on the same SHA passed. Nothing about that combination relates to a GitHub API quota, so it reads like a platform break but is not one.

When this PR was opened the failure was also *silent* on the Python side: `_do_sync` catches the per-repo exception, `camoufox fetch` returns without an error code, and the image shipped with no browser, dying a step later in `Test image`. #310 has since added `test -x "$CAMOUFOX_BINARY"` to the same `RUN`, so a fetch that lands no browser now fails the build. What is left to fix is the 403 itself.

## Change

- Pass `GITHUB_TOKEN` into both camoufox builds as a **BuildKit secret**, lifting the budget to 1000 requests/hour per repository. A secret rather than a build arg keeps the token out of the image layers and out of `docker history`. Builds that pass no secret (local, forks) stay unauthenticated and still work.
- Read the secret only when it is readable, so an absent or unreadable file leaves `GITHUB_TOKEN` **unset** rather than set to an empty string ([review comment](https://github.com/apify/apify-actor-docker/pull/309#discussion_r3968346132)).
- `mode=0444` on the node mount only — that stage runs as `myuser`, and secrets default to root-owned `0400`. The Python stage runs as root, so its default is correct.

`camoufox-js` throws on a failed fetch, so the node image was never silently broken — it gets the token but needs no guard.

## Verification

The original 403 can't be reproduced on demand, so the same code path was driven with a deliberately invalid token.

**Full local image builds** (as originally opened):

| Case | Result |
|---|---|
| Invalid token | `401 Client Error: Unauthorized` → build fails. Proves the secret reaches camoufox's request headers. |
| No secret | `Synced 30 versions from 3 repos.` → `Camoufox installed: 152.0.4-beta.30` → green |
| `docker run` image test | `All browser tests passed.` |
| Node image build | green |

**After the review change** (buildkit, non-root stage, current shape):

| Case | Result |
|---|---|
| No secret | `GITHUB_TOKEN` unset in the child process; the `&&` chain continues |
| Secret mounted | token present in the child process |
| `mode=0444` removed (control) | unset — the shape this replaced produced an empty string here |
| Merged chain incl. #310's symlink work | completes, `camoufox-current/camoufox-bin` resolves |

hadolint matches the `master` baseline exactly on both Dockerfiles (zero new findings), as does `docker buildx build --call=check`. Token absent from `docker history`.

## Notes for review

- The changed `RUN` instructions invalidate the GHA layer cache once; the first run after merge rebuilds the camoufox layer on every leg.
- `master` is merged in to pick up #310, which reworked the same `RUN` block. This PR's own `installed_verstr` assertion was dropped as redundant with #310's `test -x "$CAMOUFOX_BINARY"` — both fail the build on a fetch that lands no browser.
- CI only ever exercises the **authenticated** path: the `secrets:` block is on the build steps with no event guard, so every leg runs with a token. The token-less path is covered by the table above, not by CI.
- The secret is mounted on the `pull_request` build steps too, so a PR editing the Dockerfile could read `/run/secrets/github_token` at build time. Fork PRs get a read-only token by design and same-repo branches already imply write access. `build-main` has no explicit `permissions:` block; scoping one down would be a separate change.
- Local `make test-*-camoufox` targets can't pass a token, so heavy local iteration still shares the 60/hour budget. Left alone deliberately — wiring an optional secret through four Makefile targets needs `$(COMMA)` escaping and full image builds to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
