### PR TITLE
fix: resolve Camoufox browser and certificate library paths

### DIFF
--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -26,8 +26,8 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/pw-browsers
 # Tell the crawlee cli that we already have browsers installed, so it skips installing them
 ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 
-# Camoufox stores its browser in ~/.cache/camoufox
-ENV APIFY_DEFAULT_BROWSER_PATH=/home/myuser/.cache/camoufox/camoufox-bin
+# Stable symlink to the installed Camoufox executable.
+ENV APIFY_DEFAULT_BROWSER_PATH=/home/myuser/.cache/camoufox-bin
 
 # Prevent installing of browsers by future `npm install`.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
@@ -139,9 +139,12 @@ RUN npm --quiet set progress=false \
     \
     # Install Camoufox browser
     && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 npx camoufox-js fetch \
-    # Overrides the dynamic library used by Firefox to determine trusted root certificates with p11-kit-trust.so, which loads the system certificates.
-    && rm -f /home/myuser/.cache/camoufox/libnssckbi.so \
-    && ln -s $(ls -d /usr/lib/*-linux-gnu)/pkcs11/p11-kit-trust.so /home/myuser/.cache/camoufox/libnssckbi.so \
+    # Resolve both flat and versioned Camoufox cache layouts.
+    && CAMOUFOX_BINARY="$(find /home/myuser/.cache/camoufox -type f -name camoufox-bin)" \
+    && test -x "$CAMOUFOX_BINARY" \
+    && ln -s "$CAMOUFOX_BINARY" "$APIFY_DEFAULT_BROWSER_PATH" \
+    # Load system certificates from the browser's own library directory.
+    && ln -sf "$(ls -d /usr/lib/*-linux-gnu)/pkcs11/p11-kit-trust.so" "$(dirname "$CAMOUFOX_BINARY")/libnssckbi.so" \
     \
     && npm install --omit=dev --omit=optional --no-package-lock --prefer-online \
     && npm install --no-package-lock --prefer-online --no-save impit@latest \

--- a/node-playwright-camoufox/Dockerfile
+++ b/node-playwright-camoufox/Dockerfile
@@ -26,8 +26,8 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/pw-browsers
 # Tell the crawlee cli that we already have browsers installed, so it skips installing them
 ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 
-# Stable symlink to the installed Camoufox executable.
-ENV APIFY_DEFAULT_BROWSER_PATH=/home/myuser/.cache/camoufox-bin
+# Stable path through a symlink to the installed Camoufox directory.
+ENV APIFY_DEFAULT_BROWSER_PATH=/home/myuser/.cache/camoufox-current/camoufox-bin
 
 # Prevent installing of browsers by future `npm install`.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
@@ -142,7 +142,7 @@ RUN npm --quiet set progress=false \
     # Resolve both flat and versioned Camoufox cache layouts.
     && CAMOUFOX_BINARY="$(find /home/myuser/.cache/camoufox -type f -name camoufox-bin)" \
     && test -x "$CAMOUFOX_BINARY" \
-    && ln -s "$CAMOUFOX_BINARY" "$APIFY_DEFAULT_BROWSER_PATH" \
+    && ln -s "$(dirname "$CAMOUFOX_BINARY")" "$(dirname "$APIFY_DEFAULT_BROWSER_PATH")" \
     # Load system certificates from the browser's own library directory.
     && ln -sf "$(ls -d /usr/lib/*-linux-gnu)/pkcs11/p11-kit-trust.so" "$(dirname "$CAMOUFOX_BINARY")/libnssckbi.so" \
     \

--- a/python-playwright-camoufox/Dockerfile
+++ b/python-playwright-camoufox/Dockerfile
@@ -46,8 +46,8 @@ ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 # Prevent playwright from downloading browsers when users install playwright via pip
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
-# Stable symlink to the installed Camoufox executable.
-ENV APIFY_DEFAULT_BROWSER_PATH=/root/.cache/camoufox-bin
+# Stable path through a symlink to the installed Camoufox directory.
+ENV APIFY_DEFAULT_BROWSER_PATH=/root/.cache/camoufox-current/camoufox-bin
 
 # Copy the script for registering intermediate certificates and the pre-downloaded certificates
 COPY ./register_intermediate_certs.sh ./register_intermediate_certs.sh
@@ -114,7 +114,7 @@ RUN python -m pip install --upgrade \
     # Resolve both flat and versioned Camoufox cache layouts.
     && CAMOUFOX_BINARY="$(find /root/.cache/camoufox -type f -name camoufox-bin)" \
     && test -x "$CAMOUFOX_BINARY" \
-    && ln -s "$CAMOUFOX_BINARY" "$APIFY_DEFAULT_BROWSER_PATH" \
+    && ln -s "$(dirname "$CAMOUFOX_BINARY")" "$(dirname "$APIFY_DEFAULT_BROWSER_PATH")" \
     # Load system certificates from the browser's own library directory.
     && ln -sf "$(ls -d /usr/lib/*-linux-gnu)/pkcs11/p11-kit-trust.so" "$(dirname "$CAMOUFOX_BINARY")/libnssckbi.so"
 

--- a/python-playwright-camoufox/Dockerfile
+++ b/python-playwright-camoufox/Dockerfile
@@ -46,8 +46,8 @@ ENV CRAWLEE_SKIP_BROWSER_INSTALL=1
 # Prevent playwright from downloading browsers when users install playwright via pip
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
-# Camoufox stores its browser in ~/.cache/camoufox
-ENV APIFY_DEFAULT_BROWSER_PATH=/root/.cache/camoufox/camoufox-bin
+# Stable symlink to the installed Camoufox executable.
+ENV APIFY_DEFAULT_BROWSER_PATH=/root/.cache/camoufox-bin
 
 # Copy the script for registering intermediate certificates and the pre-downloaded certificates
 COPY ./register_intermediate_certs.sh ./register_intermediate_certs.sh
@@ -111,9 +111,12 @@ RUN python -m pip install --upgrade \
     camoufox[geoip]~=${CAMOUFOX_VERSION} \
     # Fetch the Camoufox browser
     && python -m camoufox fetch \
-    # Overrides the dynamic library used by Firefox to determine trusted root certificates with p11-kit-trust.so, which loads the system certificates.
-    && rm -f /root/.cache/camoufox/libnssckbi.so \
-    && ln -s /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so /root/.cache/camoufox/libnssckbi.so
+    # Resolve both flat and versioned Camoufox cache layouts.
+    && CAMOUFOX_BINARY="$(find /root/.cache/camoufox -type f -name camoufox-bin)" \
+    && test -x "$CAMOUFOX_BINARY" \
+    && ln -s "$CAMOUFOX_BINARY" "$APIFY_DEFAULT_BROWSER_PATH" \
+    # Load system certificates from the browser's own library directory.
+    && ln -sf "$(ls -d /usr/lib/*-linux-gnu)/pkcs11/p11-kit-trust.so" "$(dirname "$CAMOUFOX_BINARY")/libnssckbi.so"
 
 # Copy the dummy source code to the image
 COPY --chown=myuser:myuser . .


### PR DESCRIPTION
The Camoufox images assume a flat browser cache. The current Python wrapper installs into a versioned directory, leaving the `libnssckbi.so` override unused and `APIFY_DEFAULT_BROWSER_PATH` pointing at a missing executable.

Resolve the installed `camoufox-bin` in both Node and Python images, put the p11-kit symlink beside it, and expose the browser through a stable directory symlink outside the browser cache directory. The directory symlink also keeps companion files such as `properties.json` accessible when the Python wrapper receives an explicit executable path. This supports both flat and versioned cache layouts and fails the build if the executable is missing or ambiguous.

Validation:
- Built the Node 22 slim image on ARM64 and Python 3.14 image on AMD64, then verified the final directory-symlink adjustment in disposable containers from those builds.
- Docker build checks reported only existing warnings about empty default base-image arguments and Python's fixed platform.
- Checked the executable and certificate-library symlink targets across the Node wrapper's flat layout and Python wrapper's versioned layout.
- Launched headless through the Camoufox wrapper and headful through `APIFY_DEFAULT_BROWSER_PATH` in both images.
- Both loaded `https://example.com` and `https://incomplete-chain.badssl.com` with certificate verification enabled.
- Earlier controlled comparison: the incomplete-chain URL fails with `SEC_ERROR_UNKNOWN_ISSUER` when the library symlink is removed and returns 200 when it is present.

[🤖] Codex using GPT-6
